### PR TITLE
Use gosu to change the user running nexus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN sed \
 
 RUN useradd -r -u 200 -m -c "nexus role account" -d ${NEXUS_DATA} -s /bin/false nexus
 
-ENV GOSU_VERSION 1.7
+ENV GOSU_VERSION 1.9
 
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
     && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir -p /opt/sonatype/nexus \
     https://download.sonatype.com/nexus/3/nexus-${NEXUS_VERSION}-unix.tar.gz \
   | gunzip \
   | tar x -C /opt/sonatype/nexus --strip-components=1 nexus-${NEXUS_VERSION} \
-  && chown -R root:root /opt/sonatype/nexus 
+  && chown -R root:root /opt/sonatype/nexus
 
 # Patch nexus
 # https://support.sonatype.com/hc/en-us/articles/218729178-Nexus-Repository-Manager-3-0-0-03-Docker-Rollup-Patch
@@ -49,14 +49,27 @@ RUN sed \
 
 RUN useradd -r -u 200 -m -c "nexus role account" -d ${NEXUS_DATA} -s /bin/false nexus
 
+ENV GOSU_VERSION 1.7
+
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && rm -r /root/.gnupg/ \
+    && chmod +x /usr/local/bin/gosu
+
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081
-USER nexus
 WORKDIR /opt/sonatype/nexus
 
 ENV JAVA_MAX_MEM 1200m
 ENV JAVA_MIN_MEM 1200m
 ENV EXTRA_JAVA_OPTS ""
 
-CMD bin/nexus run
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["bin/nexus", "run"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -x
+set -eo pipefail
+
+if [ "$1" == 'bin/nexus' ]; then
+	mkdir -p "$NEXUS_DATA"
+	chown -R nexus "$NEXUS_DATA"
+	exec gosu nexus "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
When using kubernetes with persistent storage volume the filesystem is owned by root, because we want to run nexus3 under the nexus user we need to chown the data volume to the nexus user, but we can only chown if we are root.

To allow this we start the container as root and then switch to nexus using `gosu` (https://github.com/tianon/gosu)
