### PR TITLE
Change base image to java:8-jre-alpine

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+[ -d "${NEXUS_DATA}" ] || mkdir -p "${NEXUS_DATA}"
+chown -R nexus:nexus "${NEXUS_DATA}"
+
+[ -n "${JAVA_MAX_MEM}" ] && sed -i "s/-Xmx.*/-Xmx${JAVA_MAX_MEM}/g" /opt/sonatype/nexus/bin/nexus.vmoptions
+[ -n "${JAVA_MIN_MEM}" ] && sed -i "s/-Xms.*/-Xmx${JAVA_MIN_MEM}/g" /opt/sonatype/nexus/bin/nexus.vmoptions
+[ -n "${EXTRA_JAVA_OPTS}" ] && echo "${EXTRA_JAVA_OPTS}" >> /opt/sonatype/nexus/bin/nexus.vmoptions
+
+[ $# -eq 0 ] && \
+    exec su -s /bin/sh -c '/opt/sonatype/nexus/bin/nexus run' nexus || \
+    exec "$@"


### PR DESCRIPTION
[Alpine](https://hub.docker.com/_/alpine/) is an awesome docker base image, which is fabulously small. Today more and more official images turned to be based on `Alpine`, also the [java](https://hub.docker.com/r/library/java/tags/) image.

So I modify the `Dockerfile` that change the base image to `java:8-jre-alpine`, can reduce the image size.

Here is the compare:
```
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
nexus3              latest              c5dc270b3192        16 minutes ago      199.5 MB
sonatype/nexus3     latest              c76c0cad9cd4        4 months ago        445.9 MB
```