### PR TITLE
Dockerfile: CMD use the recommended 'exec' form instead of 'shell' form.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,4 @@ ENV JAVA_MAX_MEM 1200m
 ENV JAVA_MIN_MEM 1200m
 ENV EXTRA_JAVA_OPTS ""
 
-CMD bin/nexus run
+CMD ["bin/nexus", "run"]


### PR DESCRIPTION
This PR rewrites the Dockerfile CMD clause to use the [recommended](https://docs.docker.com/engine/reference/builder/#cmd) 'exec' form instead of the current 'shell' form.

This should make it easier to properly stop the container, as reported in #6.