### PR TITLE
Update image name to docker-nexus3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# sonatype/nexus3
+# sonatype/docker-nexus3
 
 A Dockerfile for Sonatype Nexus Repository Manager 3, based on CentOS.
 
 To run, binding the exposed port 8081 to the host.
 
 ```
-$ docker run -d -p 8081:8081 --name nexus sonatype/nexus3
+$ docker run -d -p 8081:8081 --name nexus sonatype/docker-nexus3
 ```
 
 To test:
@@ -19,7 +19,7 @@ To (re)build the image:
 Copy the Dockerfile and do the build-
 
 ```
-$ docker build --rm=true --tag=sonatype/nexus3 .
+$ docker build --rm=true --tag=sonatype/docker-nexus3 .
 ```
 
 
@@ -52,7 +52,7 @@ process, which runs as UID 200.
   These can be used supplied at runtime to control the JVM:
 
   ```
-  $ docker run -d -p 8081:8081 --name nexus -e JAVA_MAX_HEAP=768m sonatype/nexus3
+  $ docker run -d -p 8081:8081 --name nexus -e JAVA_MAX_HEAP=768m sonatype/docker-nexus3
   ```
 
 
@@ -68,7 +68,7 @@ for additional information.
 
   ```
   $ docker volume create --name nexus-data
-  $ docker run -d -p 8081:8081 --name nexus -v nexus-data:/nexus-data sonatype/nexus3
+  $ docker run -d -p 8081:8081 --name nexus -v nexus-data:/nexus-data sonatype/docker-nexus3
   ```
 
   2. *Mount a host directory as the volume*.  This is not portable, as it
@@ -78,5 +78,5 @@ for additional information.
 
   ```
   $ mkdir /some/dir/nexus-data && chown -R 200 /some/dir/nexus-data
-  $ docker run -d -p 8081:8081 --name nexus -v /some/dir/nexus-data:/nexus-data sonatype/nexus3
+  $ docker run -d -p 8081:8081 --name nexus -v /some/dir/nexus-data:/nexus-data sonatype/docker-nexus3
   ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   nexus:
-    image: sonatype/nexus3
+    image: sonatype/docker-nexus3
     volumes:
       - "nexus-data:/nexus-data"
     ports:


### PR DESCRIPTION
A new image has been setup in the hub for automated builds and it's name is docker-nexus3, updating our docs to reflect usage of that image.