### PR TITLE
Updating references to the non-deprecated image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sonatype/docker-nexus3
+# Sonatype Nexus3 Docker: sonatype/nexus3
 
 A Dockerfile for Sonatype Nexus Repository Manager 3, based on CentOS.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Dockerfile for Sonatype Nexus Repository Manager 3, based on CentOS.
 To run, binding the exposed port 8081 to the host.
 
 ```
-$ docker run -d -p 8081:8081 --name nexus sonatype/docker-nexus3
+$ docker run -d -p 8081:8081 --name nexus sonatype/nexus3
 ```
 
 To test:
@@ -23,7 +23,7 @@ To (re)build the image:
 Copy the Dockerfile and do the build-
 
 ```
-$ docker build --rm=true --tag=sonatype/docker-nexus3 .
+$ docker build --rm=true --tag=sonatype/nexus3 .
 ```
 
 ## Notes
@@ -55,7 +55,7 @@ process, which runs as UID 200.
   These can be used supplied at runtime to control the JVM:
 
   ```
-  $ docker run -d -p 8081:8081 --name nexus -e JAVA_MAX_MEM=768m sonatype/docker-nexus3
+  $ docker run -d -p 8081:8081 --name nexus -e JAVA_MAX_MEM=768m sonatype/nexus3
   ```
 
 * Another environment variable can be used to control the Nexus Context Path
@@ -65,7 +65,7 @@ process, which runs as UID 200.
   This can be supplied at runtime:
 
   ```
-  $ docker run -d -p 8081:8081 --name nexus -e NEXUS_CONTEXT=nexus sonatype/docker-nexus3
+  $ docker run -d -p 8081:8081 --name nexus -e NEXUS_CONTEXT=nexus sonatype/nexus3
   ```
 
 ### Persistent Data
@@ -80,7 +80,7 @@ for additional information.
 
   ```
   $ docker volume create --name nexus-data
-  $ docker run -d -p 8081:8081 --name nexus -v nexus-data:/nexus-data sonatype/docker-nexus3
+  $ docker run -d -p 8081:8081 --name nexus -v nexus-data:/nexus-data sonatype/nexus3
   ```
 
   2. *Mount a host directory as the volume*.  This is not portable, as it
@@ -90,7 +90,7 @@ for additional information.
 
   ```
   $ mkdir /some/dir/nexus-data && chown -R 200 /some/dir/nexus-data
-  $ docker run -d -p 8081:8081 --name nexus -v /some/dir/nexus-data:/nexus-data sonatype/docker-nexus3
+  $ docker run -d -p 8081:8081 --name nexus -v /some/dir/nexus-data:/nexus-data sonatype/nexus3
   ```
 
 ## Getting Help


### PR DESCRIPTION
Noticed these references to nexus-docker3 tho that is deprecated.