### PR TITLE
Introduce build arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ LABEL vendor=Sonatype \
   com.sonatype.license="Apache License, Version 2.0" \
   com.sonatype.name="Nexus Repository Manager base image"
 
+ARG NEXUS_VERSION=3.1.0-04
+ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/nexus-${NEXUS_VERSION}-unix.tar.gz
+
 RUN yum install -y \
   curl tar \
   && yum clean all
@@ -32,8 +35,7 @@ ENV JAVA_HOME=/opt/java \
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype
-ENV NEXUS_VERSION=3.1.0-04 \
-  NEXUS_HOME=${SONATYPE_DIR}/nexus \
+ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
   NEXUS_DATA=/nexus-data \
   NEXUS_CONTEXT='' \
   SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work
@@ -50,7 +52,7 @@ RUN mkdir -p /opt \
 # install nexus
 RUN mkdir -p ${NEXUS_HOME} \
   && curl --fail --silent --location --retry 3 \
-    https://download.sonatype.com/nexus/3/nexus-${NEXUS_VERSION}-unix.tar.gz \
+    ${NEXUS_DOWNLOAD_URL} \
   | gunzip \
   | tar x -C ${NEXUS_HOME} --strip-components=1 nexus-${NEXUS_VERSION} \
   && chown -R root:root ${NEXUS_HOME}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Dockerfile for Sonatype Nexus Repository Manager 3, based on CentOS.
 
 * [Notes](#notes)
   * [Persistent Data](#persistent-data)
-  * [Build Args](#build-ars)
+  * [Build Args](#build-args)
 * [Getting Help](#getting-help)
 
 To run, binding the exposed port 8081 to the host.
@@ -76,7 +76,7 @@ with Docker. See [Managing Data in Containers](https://docs.docker.com/engine/tu
 for additional information.
 
   1. *Use a data volume*.  Since data volumes are persistent
-  until no containers use them, a volume can be created specifically for 
+  until no containers use them, a volume can be created specifically for
   this purpose.  This is the recommended approach.  
 
   ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A Dockerfile for Sonatype Nexus Repository Manager 3, based on CentOS.
 
 * [Notes](#notes)
   * [Persistent Data](#persistent-data)
+  * [Build Args](#build-ars)
 * [Getting Help](#getting-help)
 
 To run, binding the exposed port 8081 to the host.
@@ -92,6 +93,16 @@ for additional information.
   $ mkdir /some/dir/nexus-data && chown -R 200 /some/dir/nexus-data
   $ docker run -d -p 8081:8081 --name nexus -v /some/dir/nexus-data:/nexus-data sonatype/nexus3
   ```
+
+### Build Args
+
+The Dockerfile contains two build arguments (`NEXUS_VERSION` & `NEXUS_DOWNLOAD_URL`) that can be used to customize what
+version of, and from where, Nexus Repository Manager is downloaded. This is useful mostly for testing purposes as the
+Dockerfile may be dependent on a very specific version of Nexus Repository Manager.
+
+```
+docker build --rm --tag nexus-custom --build-arg NEXUS_VERSION=3.x.y --build-arg NEXUS_DOWNLOAD_URL=http://.../nexus-3.x.y-unix.tar.gz .
+```
 
 ## Getting Help
 


### PR DESCRIPTION
Allow NEXUS_VERSION and NEXUS_DOWNLOAD_URL to be overridden at build time, e.g.
```
docker build -t nexus-custom --build-arg NEXUS_VERSION=3.x.y --build-arg NEXUS_DOWNLOAD_URL=http://.../nexus-3.x.y-unix.tar.gz .
```