### PR TITLE
[NEXUS-12835] Move java memory opts to INSTALL4J_ADD_VM_PARAMS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,11 @@ RUN mkdir -p ${NEXUS_HOME} \
 # configure nexus
 RUN sed \
     -e '/^nexus-context/ s:$:${NEXUS_CONTEXT}:' \
-    -i ${NEXUS_HOME}/etc/nexus-default.properties
+    -i ${NEXUS_HOME}/etc/nexus-default.properties \
+  && sed \
+    -e '/^-Xms/d' \
+    -e '/^-Xmx/d' \
+    -i ${NEXUS_HOME}/bin/nexus.vmoptions
 
 RUN useradd -r -u 200 -m -c "nexus role account" -d ${NEXUS_DATA} -s /bin/false nexus \
   && mkdir -p ${NEXUS_DATA}/etc ${NEXUS_DATA}/log ${NEXUS_DATA}/tmp ${SONATYPE_WORK} \
@@ -73,8 +77,6 @@ EXPOSE 8081
 USER nexus
 WORKDIR ${NEXUS_HOME}
 
-ENV JAVA_MAX_MEM=1200m \
-  JAVA_MIN_MEM=1200m \
-  EXTRA_JAVA_OPTS=""
+ENV INSTALL4J_ADD_VM_PARAMS="-Xms1200m -Xmx1200m"
 
 CMD ["bin/nexus", "run"]

--- a/README.md
+++ b/README.md
@@ -44,19 +44,14 @@ $ docker logs -f nexus
 logs, and storage. This directory needs to be writable by the Nexus
 process, which runs as UID 200.
 
-* Three environment variables can be used to control the JVM arguments
+* There is an environment variable that can used to pass JVM arguments to the startup script
 
-  * `JAVA_MAX_MEM`, passed as -Xmx.  Defaults to `1200m`.
+  * `INSTALL4J_ADD_VM_PARAMS`, passed to the Install4J startup script. Defaults to `-Xms1200m -Xmx1200m`.
 
-  * `JAVA_MIN_MEM`, passed as -Xms.  Defaults to `1200m`.
-
-  * `EXTRA_JAVA_OPTS`.  Additional options can be passed to the JVM via
-  this variable.
-
-  These can be used supplied at runtime to control the JVM:
+  This can be supplied at runtime:
 
   ```
-  $ docker run -d -p 8081:8081 --name nexus -e JAVA_MAX_MEM=768m sonatype/nexus3
+  $ docker run -d -p 8081:8081 --name nexus -e INSTALL4J_ADD_VM_PARAMS="-Xms2g -Xmx2g" sonatype/nexus3
   ```
 
 * Another environment variable can be used to control the Nexus Context Path


### PR DESCRIPTION
With this change the heap size settings can be overriden as follows:
```
docker run -e INSTALL4J_ADD_VM_PARAMS="-Xms2g -Xmx2g" sonatype/nexus3
```