### PR TITLE
[NEXUS-14427] Usage of the UID via environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,10 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
   NEXUS_CONTEXT='' \
   SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work
 
+# configure the user id to be used with 
+# volume storage.
+ENV USERID=200
+
 # install Oracle JRE
 RUN mkdir -p /opt \
   && curl --fail --silent --location --retry 3 \
@@ -68,7 +72,7 @@ RUN sed \
     -e '/^-XX:MaxDirectMemorySize/d' \
     -i ${NEXUS_HOME}/bin/nexus.vmoptions
 
-RUN useradd -r -u 200 -m -c "nexus role account" -d ${NEXUS_DATA} -s /bin/false nexus \
+RUN useradd -r -u ${USERID} -m -c "nexus role account" -d ${NEXUS_DATA} -s /bin/false nexus \
   && mkdir -p ${NEXUS_DATA}/etc ${NEXUS_DATA}/log ${NEXUS_DATA}/tmp ${SONATYPE_WORK} \
   && ln -s ${NEXUS_DATA} ${SONATYPE_WORK}/nexus3 \
   && chown -R nexus:nexus ${NEXUS_DATA}

--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ for additional information.
   $ docker run -d -p 8081:8081 --name nexus -v /some/dir/nexus-data:/nexus-data sonatype/nexus3
   ```
 
+  A simpler solution is to use the environment USERID of the docker image which looks like this:
+
+  ```
+  $ docker run -d -p 8081:8081 --env USERID=`id -u` --name nexus -v /some/dir/nexus-data:/nexus-data sonatype/nexus3
+  ```
+
+  The `id -u` will give back the user id number only. You can of course give the id literally.
+
 ### Build Args
 
 The Dockerfile contains two build arguments (`NEXUS_VERSION` & `NEXUS_DOWNLOAD_URL`) that can be used to customize what


### PR DESCRIPTION
Introduced the usage of an environment variable
for the user id to be used instead of hard coding
it.

This pull request makes the following changes:
* NEXUS-14427
