### PR TITLE
Update to Oracle Java SE Runtime Environment 8u152

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,9 @@ RUN yum install -y \
 # configure java runtime
 ENV JAVA_HOME=/opt/java \
   JAVA_VERSION_MAJOR=8 \
-  JAVA_VERSION_MINOR=144 \
-  JAVA_VERSION_BUILD=01 \
-  JAVA_DOWNLOAD_HASH=090f390dda5b47b9b721c7dfaa008135
+  JAVA_VERSION_MINOR=152 \
+  JAVA_VERSION_BUILD=16 \
+  JAVA_DOWNLOAD_HASH=aa0333dd3019491ca4f6ddbe78cdb6d0
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype


### PR DESCRIPTION
The previous version (8u144) does not seem to be available anymore, hence
building is not possible.

Release notes:
http://www.oracle.com/technetwork/java/javase/8u152-relnotes-3850503.html

Download page:
http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html