### PR TITLE
Fixed incorrect checksum property variable for chef recipe

### DIFF
--- a/solo.json.erb
+++ b/solo.json.erb
@@ -40,7 +40,7 @@ raise RuntimeError, 'environment variable NEXUS_DATA is required' if ENV['NEXUS_
   :nexus_repository_manager => {
     :version => ENV['NEXUS_VERSION'],
     :nexus_download_url => ENV['NEXUS_DOWNLOAD_URL'],
-    :checksum => ENV['NEXUS_DOWNLOAD_SHA256_HASH'],
+    :nexus_download_sha256 => ENV['NEXUS_DOWNLOAD_SHA256_HASH'],
     :sonatype => {
       :path => ENV['SONATYPE_DIR'],
     },


### PR DESCRIPTION
The variable being used for the checksum is not used by the chef download recipe for nexus.