### PR TITLE
Red hat Certified Image

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,86 @@
+# Copyright (c) 2016-present Sonatype, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.access.redhat.com/rhel7/rhel
+
+MAINTAINER Sonatype <cloud-ops@sonatype.com>
+
+LABEL name="Nexus Repository Manager" \
+      vendor=Sonatype \
+      version="3.6.2-01" \
+      release="3.6.2" \
+      url="https://sonatype.com" \
+      summary="The Nexus Repository Manager server \
+          with universal support for popular component formats." \
+      run="docker run -d --name NAME \
+          -p 8081:8081 \
+          IMAGE" \
+      stop="docker stop NAME" \
+      com.sonatype.license="Apache License, Version 2.0" \
+      com.sonatype.name="Nexus Repository Manager base image" \
+      io.k8s.description="The Nexus Repository Manager server \
+          with universal support for popular component formats." \
+      io.k8s.display-name="Nexus Repository Manager" \
+      io.openshift.expose-services="8081:8081" \
+      io.openshift.tags="Sonatype,Nexus,Repository Manager"
+
+ARG NEXUS_VERSION=3.6.2-01
+ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/nexus-${NEXUS_VERSION}-unix.tar.gz
+ARG NEXUS_DOWNLOAD_SHA256_HASH=d055006ce90778ca7441efcccb2c979429fe296d1871642b99da2e97c04724a5
+
+ENV JAVA_HOME=/opt/java \
+    JAVA_VERSION_MAJOR=8 \
+    JAVA_VERSION_MINOR=152 \
+    JAVA_VERSION_BUILD=16 \
+    JAVA_DOWNLOAD_HASH=aa0333dd3019491ca4f6ddbe78cdb6d0
+
+ENV JAVA_URL=http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_DOWNLOAD_HASH}/server-jre-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz \
+    JAVA_DOWNLOAD_SHA256_HASH=e8a341ce566f32c3d06f6d0f0eeea9a0f434f538d22af949ae58bc86f2eeaae4
+
+# configure nexus runtime
+ENV SONATYPE_DIR=/opt/sonatype
+ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
+    NEXUS_DATA=/nexus-data \
+    NEXUS_CONTEXT='' \
+    SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work
+
+ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20171127-222629.c2a02ed"
+ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexus-repository-manager/releases/download/${NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION}/chef-nexus-repository-manager.tar.gz"
+
+ADD solo.json.erb /var/chef/solo.json.erb
+
+ADD red-hat-assets/help.1 red-hat-assets/uid_entrypoint red-hat-assets/licenses /
+
+# Install using chef-solo
+RUN curl -L https://www.getchef.com/chef/install.sh | bash \
+    && /opt/chef/embedded/bin/erb /var/chef/solo.json.erb > /var/chef/solo.json \
+    && chef-solo \
+       --recipe-url ${NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL} \
+       --json-attributes /var/chef/solo.json \
+    && rpm -qa *chef* | xargs rpm -e \
+    && rpm --rebuilddb \
+    && rm -rf /etc/chef \
+    && rm -rf /opt/chefdk \
+    && rm -rf /var/cache/yum \
+    && rm -rf /var/chef
+
+VOLUME ${NEXUS_DATA}
+
+EXPOSE 8081
+USER nexus
+
+ENV INSTALL4J_ADD_VM_PARAMS="-Xms1200m -Xmx1200m -XX:MaxDirectMemorySize=2g -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
+
+ENTRYPOINT ["/uid_entrypoint"]
+CMD ["sh", "-c", "${SONATYPE_DIR}/start-nexus-repository-manager.sh"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A Dockerfile for Sonatype Nexus Repository Manager 3, based on CentOS.
 * [Building the Nexus Repository Manager image](#building-the-nexus-repository-manager-image)
 * [Chef Solo for Runtime and Application](#chef-solo-for-runtime-and-application)
 * [Testing the Dockerfile](#testing-the-dockerfile)
+* [Red Hat Certified Image](#red-hat-certified-image)
 * [Notes](#notes)
   * [Persistent Data](#persistent-data)
 * [Getting Help](#getting-help)
@@ -77,6 +78,19 @@ We are using `rspec` as the test framework. `serverspec` provides a docker backe
  (e.g. yum, apt,...).
 
     rspec [--backtrace] spec/Dockerfile_spec.rb
+
+## Red Hat Certified Image
+
+A Red Hat certified container image can be created using Dockerfile.rhel which pulls from assets in the red-hat-assets folder. The 
+image includes additional meta data to comform with Atomic and OpenShift standards, a directory with the licesense applicable to the
+software and a man file for help on how to use the software. It also uses an ENTRYPOINT which adds the running user's id from host 
+in order to set appropriate permissions on mounted volumes.
+
+### Red Hat help.1
+
+The man file included in the Red Hat image is generated from this [help markdown](red-hat-assets/help.md). Markdown can be converted to
+the appropriate format using [md2roff](https://github.com/nereusx/md2roff). This process is currently not part of the automated build
+and needs to be done manually after any update to the help markdown.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ We are using `rspec` as the test framework. `serverspec` provides a docker backe
 
 ## Red Hat Certified Image
 
-A Red Hat certified container image can be created using Dockerfile.rhel which pulls from assets in the red-hat-assets folder. The 
-image includes additional meta data to comform with Atomic and OpenShift standards, a directory with the licesense applicable to the
-software and a man file for help on how to use the software. It also uses an ENTRYPOINT which adds the running user's id from host 
-in order to set appropriate permissions on mounted volumes.
+A Red Hat certified container image can be created using Dockerfile.rhel which pulls from assets in the red-hat-assets
+folder. The image includes additional meta data to comform with Atomic and OpenShift standards, a directory with the
+licesense applicable to the software and a man file for help on how to use the software. It also uses an ENTRYPOINT
+which adds the running user's id from host in order to set appropriate permissions on mounted volumes.
 
 ### Red Hat help.1
 

--- a/red-hat-assets/help.1
+++ b/red-hat-assets/help.1
@@ -1,0 +1,74 @@
+.PP
+% 
+.BR NEXUS (1) 
+Container Image Pages
+% Sonatype
+% November 21, 2016
+.TH NAME
+.PP
+nexus \- Nexus Repository Manager container image
+.SH DESCRIPTION
+.PP
+The nexus image provides a containerized packaging of the Nexus Repository Manager.
+Nexus Repository Manager is a repository manager with universal support for popular component formats including Maven, Docker, NuGet, npm, PyPi, Bower and more.
+.PP
+The nexus image is designed to be run by the atomic command with one of these options:
+.PP
+\fB\fCrun\fR
+.PP
+Starts the installed container with selected privileges to the host.
+.PP
+\fB\fCstop\fR
+.PP
+Stops the installed container
+.PP
+The container itself consists of:
+    \- Linux base image
+    \- Oracle Java JDK
+    \- Nexus Repository Manager
+    \- Atomic help file
+.PP
+Files added to the container during docker build include: /help.1.
+.SH USAGE
+.PP
+To use the nexus container, you can run the atomic command with run, stop, or uninstall options:
+.PP
+To run the nexus container:
+.IP
+atomic run nexus
+.PP
+To stop the nexus container (after it is installed), run:
+.IP
+atomic stop nexus
+.SH LABELS
+.PP
+The nexus container includes the following LABEL settings:
+.PP
+That atomic command runs the docker command set in this label:
+.PP
+\fB\fCRUN=\fR
+.IP
+LABEL RUN='docker run \-d \-p 8081:8081 \-\-name ${NAME} ${IMAGE}'
+.IP
+The contents of the RUN label tells an \fB\fCatomic run nexus\fR command to open port 8081 & set the name of the container.
+.PP
+\fB\fCSTOP=\fR
+.IP
+LABEL STOP='docker stop ${NAME}'
+.PP
+\fB\fCName=\fR
+.PP
+The registry location and name of the image. For example, Name="Nexus Repository Manager".
+.PP
+\fB\fCVersion=\fR
+.PP
+The Nexus Repository Manager version from which the container was built. For example, Version="3.0.2\-02".
+.PP
+When the atomic command runs the nexus container, it reads the command line associated with the selected option
+from a LABEL set within the Docker container itself. It then runs that command. The following sections detail
+each option and associated LABEL:
+.SH SECURITY IMPLICATIONS
+.PP
+\fB\fC\-d\fR
+.PP
+Runs continuously as a daemon process in the background

--- a/red-hat-assets/help.md
+++ b/red-hat-assets/help.md
@@ -1,0 +1,72 @@
+% NEXUS(1) Container Image Pages
+% Sonatype
+% November 21, 2016
+
+# NAME
+nexus \- Nexus Repository Manager container image
+
+# DESCRIPTION
+The nexus image provides a containerized packaging of the Nexus Repository Manager.
+Nexus Repository Manager is a repository manager with universal support for popular component formats including Maven, Docker, NuGet, npm, PyPi, Bower and more.
+
+The nexus image is designed to be run by the atomic command with one of these options:
+
+`run`
+
+Starts the installed container with selected privileges to the host.
+
+`stop`
+
+Stops the installed container
+
+The container itself consists of:
+    - Linux base image
+    - Oracle Java JDK
+    - Nexus Repository Manager
+    - Atomic help file
+
+Files added to the container during docker build include: /help.1.
+
+# USAGE
+To use the nexus container, you can run the atomic command with run, stop, or uninstall options:
+
+To run the nexus container:
+
+  atomic run nexus
+
+To stop the nexus container (after it is installed), run:
+
+  atomic stop nexus
+
+# LABELS
+The nexus container includes the following LABEL settings:
+
+That atomic command runs the docker command set in this label:
+
+`RUN=`
+
+  LABEL RUN='docker run -d -p 8081:8081 --name ${NAME} ${IMAGE}'
+
+  The contents of the RUN label tells an `atomic run nexus` command to open port 8081 & set the name of the container.
+
+`STOP=`
+
+  LABEL STOP='docker stop ${NAME}'
+
+`Name=`
+
+The registry location and name of the image. For example, Name="Nexus Repository Manager".
+
+`Version=`
+
+The Nexus Repository Manager version from which the container was built. For example, Version="3.0.2-02".
+
+When the atomic command runs the nexus container, it reads the command line associated with the selected option
+from a LABEL set within the Docker container itself. It then runs that command. The following sections detail
+each option and associated LABEL:
+
+# SECURITY IMPLICATIONS
+
+`-d`
+
+Runs continuously as a daemon process in the background

--- a/red-hat-assets/licenses/LICENSE
+++ b/red-hat-assets/licenses/LICENSE
@@ -1,0 +1,10 @@
+Sonatype Nexus (TM) Open Source Version
+Copyright (c) 2008-present Sonatype, Inc.
+All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+Eclipse Foundation. All other trademarks are the property of their respective owners.

--- a/red-hat-assets/uid_entrypoint
+++ b/red-hat-assets/uid_entrypoint
@@ -1,0 +1,6 @@
+#!/bin/sh
+USER_ID=$(id -u)
+if [ ${USER_UID} != ${USER_ID} ]; then
+    sed "s@${USER_NAME}:x:\${USER_ID}:@${USER_NAME}:x:${USER_ID}:@g" /etc/passwd.template > /etc/passwd
+fi
+exec "$@"


### PR DESCRIPTION
Moving Red Hat Certified Image from [sonatype/docker-rhel-nexus](https://github.com/sonatype/docker-rhel-nexus) to this repository in an effort to centralize offerings and use similar tooling.
