### PR TITLE
Switchover to OpenJDK

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,6 +28,7 @@ Sonatype internal people:
 * [@jeviolle](https://github.com/jeviolle/) (Rick Briganti/The Money)
 * [@jswank](https://github.com/jswank/) (Jason Swank)
 * [@DarthHater](https://github.com/darthhater/) (Jeffry Hesse)
+* [@dawidsawa](https://github.com/dawidsawa/) (Dawid Sawa)
 
 External contributors:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,6 @@ ARG NEXUS_VERSION=3.15.1-01
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/nexus-${NEXUS_VERSION}-unix.tar.gz
 ARG NEXUS_DOWNLOAD_SHA256_HASH=5ddf03e35f92b4b90eb290f48ada15bb8b15ba5b76e7f190a24ede0d8982ffcf
 
-ARG JAVA_URL=https://download.oracle.com/otn-pub/java/jdk/8u202-b08/1961070e4c9b4e26a04e7f5a083f551e/server-jre-8u202-linux-x64.tar.gz
-ARG JAVA_DOWNLOAD_SHA256_HASH=61292e9d9ef84d9702f0e30f57b208e8fbd9a272d87cd530aece4f5213c98e4e
-
-ENV JAVA_HOME=/opt/java
-
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype
 ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \

--- a/Dockerfile.rh.centos
+++ b/Dockerfile.rh.centos
@@ -41,11 +41,6 @@ ARG NEXUS_VERSION=3.15.1-01
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/nexus-${NEXUS_VERSION}-unix.tar.gz
 ARG NEXUS_DOWNLOAD_SHA256_HASH=5ddf03e35f92b4b90eb290f48ada15bb8b15ba5b76e7f190a24ede0d8982ffcf
 
-ARG JAVA_URL=https://download.oracle.com/otn-pub/java/jdk/8u202-b08/1961070e4c9b4e26a04e7f5a083f551e/server-jre-8u202-linux-x64.tar.gz
-ARG JAVA_DOWNLOAD_SHA256_HASH=61292e9d9ef84d9702f0e30f57b208e8fbd9a272d87cd530aece4f5213c98e4e
-
-ENV JAVA_HOME=/opt/java
-
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype
 ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \

--- a/Dockerfile.rh.el
+++ b/Dockerfile.rh.el
@@ -41,11 +41,6 @@ ARG NEXUS_VERSION=3.15.1-01
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/nexus-${NEXUS_VERSION}-unix.tar.gz
 ARG NEXUS_DOWNLOAD_SHA256_HASH=5ddf03e35f92b4b90eb290f48ada15bb8b15ba5b76e7f190a24ede0d8982ffcf
 
-ARG JAVA_URL=https://download.oracle.com/otn-pub/java/jdk/8u202-b08/1961070e4c9b4e26a04e7f5a083f551e/server-jre-8u202-linux-x64.tar.gz
-ARG JAVA_DOWNLOAD_SHA256_HASH=61292e9d9ef84d9702f0e30f57b208e8fbd9a272d87cd530aece4f5213c98e4e
-
-ENV JAVA_HOME=/opt/java
-
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype
 ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,9 +13,6 @@ properties([
     string(defaultValue: '', description: 'New Nexus Repository Manager Version Sha256', name: 'nexus_repository_manager_version_sha'),
 
     string(defaultValue: '', description: 'New Nexus Repository Manager Cookbook Version', name: 'nexus_repository_manager_cookbook_version'),
-
-    string(defaultValue: '', description: 'New JRE Url', name: 'oracle_jre_url'),
-    string(defaultValue: '', description: 'New JRE Sha256', name: 'oracle_jre_sha')
   ])
 ])
 
@@ -71,12 +68,6 @@ node('ubuntu-zion') {
           dockerFileLocations.each { updateRepositoryCookbookVersion(it) }
         }
       }
-      if (params.oracle_jre_url && params.oracle_jre_sha) {
-        stage('Update JRE Url') {
-          OsTools.runSafe(this, "git checkout ${branch}")
-          dockerFileLocations.each { updateJreUrl(it) }
-        }
-      }
     }
     stage('Build') {
       gitHub.statusUpdate commitId, 'pending', 'build', 'Build is running'
@@ -113,8 +104,7 @@ node('ubuntu-zion') {
       return
     }
     if (params.nexus_repository_manager_version && params.nexus_repository_manager_version_sha 
-          || params.nexus_repository_manager_cookbook_version
-          || params.oracle_jre_url && params.oracle_jre_sha) {
+          || params.nexus_repository_manager_cookbook_version) {
       stage('Commit Automated Code Update') {
         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'integrations-github-api',
                         usernameVariable: 'GITHUB_API_USERNAME', passwordVariable: 'GITHUB_API_PASSWORD']]) {
@@ -122,9 +112,7 @@ node('ubuntu-zion') {
             params.nexus_repository_manager_version && params.nexus_repository_manager_version_sha ?
                 "Update Repository Manager to ${params.nexus_repository_manager_version}." : "",
             params.nexus_repository_manager_cookbook_version ?
-                "Update Repository Manager Cookbook to ${params.nexus_repository_manager_cookbook_version}." : "",
-            params.oracle_jre_url && params.oracle_jre_sha ?
-                "Update Oracle JRE to ${(params.oracle_jre_url =~ /(\du\d{3}\-b\d{2})/)[0][0]}." : ""
+                "Update Repository Manager Cookbook to ${params.nexus_repository_manager_cookbook_version}." : ""
           ].findAll({ it }).join(' ')
           OsTools.runSafe(this, """
             git add .
@@ -240,18 +228,6 @@ def updateRepositoryCookbookVersion(dockerFileLocation) {
   def cookbookVersionRegex = /(ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION=")(release-\d\.\d\.\d{8}\-\d{6}\.[a-z0-9]{7})(")/
 
   dockerFile = dockerFile.replaceAll(cookbookVersionRegex, "\$1${params.nexus_repository_manager_cookbook_version}\$3")
-
-  writeFile(file: dockerFileLocation, text: dockerFile)
-}
-
-def updateJreUrl(dockerFileLocation) {
-  def dockerFile = readFile(file: dockerFileLocation)
-
-  def jreUrlRegex = /(ARG JAVA_URL=)(http.*-linux-x64\.tar\.gz)/
-  def jreShaRegex = /(JAVA_DOWNLOAD_SHA256_HASH=)([A-Fa-f0-9]{64})/
-
-  dockerFile = dockerFile.replaceAll(jreUrlRegex, "\$1${params.oracle_jre_url}")
-  dockerFile = dockerFile.replaceAll(jreShaRegex, "\$1${params.oracle_jre_sha}")
 
   writeFile(file: dockerFileLocation, text: dockerFile)
 }

--- a/solo.json.erb
+++ b/solo.json.erb
@@ -25,18 +25,8 @@ raise RuntimeError, 'environment variable NEXUS_DATA is required' if ENV['NEXUS_
   :java => {
     :jdk_version => ENV['JAVA_VERSION_MAJOR'],
     :java_home => ENV['JAVA_HOME'],
-    :install_flavor => 'oracle',
-    :oracle => {
-      :accept_oracle_download_terms => true
-    },
-    :jdk => {
-      :'8' => {
-        :x86_64 => {
-          :url => ENV['JAVA_URL'],
-          :checksum => ENV['JAVA_DOWNLOAD_SHA256_HASH']
-        }
-      }
-    }
+    :install_flavor => 'openjdk',
+    :jdk_version => '8'
   },
   :nexus_repository_manager => {
     :version => ENV['NEXUS_VERSION'],


### PR DESCRIPTION
Switch from Oracle JDK to OpenJDK 8.

This pull request makes the following changes:
* Removes code related to Oracle JDK
* Uses OpenJDK 8 as dependency in Chef's recipe

It relates to the following issue #s:
* Resolves [NEXUS-18693](https://issues.sonatype.org/browse/NEXUS-18693)