### PR TITLE
NEXUS-19925: Accept Chef license

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,5 +34,6 @@ External contributors:
 
 * [@bestlong](https://github.com/bestlong/) (Yu-Lung Shao (Allen))
 * [@jperville](https://github.com/jperville/) (Julien Pervillé)
+* [@sivapalan](https://github.com/sivapalan/) (Varun Sivapalan)
 
 ![Possibly You!](http://i.imgur.com/A3eScYul.jpg)

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexu
 
 ADD solo.json.erb /var/chef/solo.json.erb
 
-ENV CHEF_LICENSE='accept-no-persist'
+ARG CHEF_LICENSE='accept-no-persist'
 
 # Install using chef-solo
 RUN curl -L https://www.getchef.com/chef/install.sh | bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexu
 
 ADD solo.json.erb /var/chef/solo.json.erb
 
+ENV CHEF_LICENSE=accept
+
 # Install using chef-solo
 RUN curl -L https://www.getchef.com/chef/install.sh | bash \
     && /opt/chef/embedded/bin/erb /var/chef/solo.json.erb > /var/chef/solo.json \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexu
 
 ADD solo.json.erb /var/chef/solo.json.erb
 
-ENV CHEF_LICENSE=accept
+ENV CHEF_LICENSE='accept-no-persist'
 
 # Install using chef-solo
 RUN curl -L https://www.getchef.com/chef/install.sh | bash \

--- a/Dockerfile.rh.centos
+++ b/Dockerfile.rh.centos
@@ -54,7 +54,7 @@ ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexu
 
 ADD solo.json.erb /var/chef/solo.json.erb
 
-ENV CHEF_LICENSE=accept
+ENV CHEF_LICENSE='accept-no-persist'
 
 # Install using chef-solo
 RUN curl -L https://www.getchef.com/chef/install.sh | bash \

--- a/Dockerfile.rh.centos
+++ b/Dockerfile.rh.centos
@@ -54,6 +54,8 @@ ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexu
 
 ADD solo.json.erb /var/chef/solo.json.erb
 
+ENV CHEF_LICENSE=accept
+
 # Install using chef-solo
 RUN curl -L https://www.getchef.com/chef/install.sh | bash \
     && /opt/chef/embedded/bin/erb /var/chef/solo.json.erb > /var/chef/solo.json \

--- a/Dockerfile.rh.centos
+++ b/Dockerfile.rh.centos
@@ -54,7 +54,7 @@ ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexu
 
 ADD solo.json.erb /var/chef/solo.json.erb
 
-ENV CHEF_LICENSE='accept-no-persist'
+ARG CHEF_LICENSE='accept-no-persist'
 
 # Install using chef-solo
 RUN curl -L https://www.getchef.com/chef/install.sh | bash \

--- a/Dockerfile.rh.el
+++ b/Dockerfile.rh.el
@@ -54,7 +54,7 @@ ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexu
 
 ADD solo.json.erb /var/chef/solo.json.erb
 
-ENV CHEF_LICENSE=accept
+ENV CHEF_LICENSE='accept-no-persist'
 
 # Install using chef-solo
 RUN curl -L https://www.getchef.com/chef/install.sh | bash \

--- a/Dockerfile.rh.el
+++ b/Dockerfile.rh.el
@@ -54,6 +54,8 @@ ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexu
 
 ADD solo.json.erb /var/chef/solo.json.erb
 
+ENV CHEF_LICENSE=accept
+
 # Install using chef-solo
 RUN curl -L https://www.getchef.com/chef/install.sh | bash \
     && /opt/chef/embedded/bin/erb /var/chef/solo.json.erb > /var/chef/solo.json \

--- a/Dockerfile.rh.el
+++ b/Dockerfile.rh.el
@@ -54,7 +54,7 @@ ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexu
 
 ADD solo.json.erb /var/chef/solo.json.erb
 
-ENV CHEF_LICENSE='accept-no-persist'
+ARG CHEF_LICENSE='accept-no-persist'
 
 # Install using chef-solo
 RUN curl -L https://www.getchef.com/chef/install.sh | bash \


### PR DESCRIPTION
The `Dockerfile`s are using the newest version of Chef. As of version 15 (See changelog: https://github.com/chef/chef/blob/master/CHANGELOG.md), _Chef Infra Client_ cannot execute without accepting the license. This causes `docker build` to fail.

This pull request makes the following changes:
* Add environment variable to accept Chef license

It relates to the following issue #s:
* Fixes NEXUS-19925
