### PR TITLE
Specify Chef version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexu
 ADD solo.json.erb /var/chef/solo.json.erb
 
 # Install using chef-solo
-RUN curl -L https://www.getchef.com/chef/install.sh | bash \
+RUN curl -L https://www.getchef.com/chef/install.sh | bash -s -- -v 14.12.9 \
     && /opt/chef/embedded/bin/erb /var/chef/solo.json.erb > /var/chef/solo.json \
     && chef-solo \
        --recipe-url ${NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexu
 ADD solo.json.erb /var/chef/solo.json.erb
 
 # Install using chef-solo
+# Chef version locked to avoid needing to accept the EULA on behalf of whomever builds the image
 RUN curl -L https://www.getchef.com/chef/install.sh | bash -s -- -v 14.12.9 \
     && /opt/chef/embedded/bin/erb /var/chef/solo.json.erb > /var/chef/solo.json \
     && chef-solo \


### PR DESCRIPTION
Lock the version to 14.x to avoid automatically accepting the EULA on behalf of a user.

The omnibus documentation suggests this method for setting the version - https://docs.chef.io/install_omnibus.html

I arbitrarily chose the latest 14.x version listed in the changelog - https://github.com/chef/chef/blob/master/CHANGELOG.md