### PR TITLE
Replaced MAINTAINER with LABEL maintainer for other Dockerfiles

### DIFF
--- a/Dockerfile.rh.centos
+++ b/Dockerfile.rh.centos
@@ -14,9 +14,8 @@
 
 FROM centos:centos7
 
-MAINTAINER Sonatype <cloud-ops@sonatype.com>
-
 LABEL name="Nexus Repository Manager" \
+      maintainer="Sonatype <cloud-ops@sonatype.com>" \
       vendor=Sonatype \
       version="3.17.0-01" \
       release="3.17.0" \

--- a/Dockerfile.rh.el
+++ b/Dockerfile.rh.el
@@ -14,9 +14,8 @@
 
 FROM registry.access.redhat.com/rhel7/rhel
 
-MAINTAINER Sonatype <cloud-ops@sonatype.com>
-
 LABEL name="Nexus Repository Manager" \
+      maintainer="Sonatype <cloud-ops@sonatype.com>" \
       vendor=Sonatype \
       version="3.17.0-01" \
       release="3.17.0" \


### PR DESCRIPTION
Working off of the latest in #111, I made updates in the spirit of #110 to also updated the remaining Dockerfiles to replace MAINTAINER with LABEL maintainer.