### PR TITLE
Update metadata for Dockerfile label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,27 @@
 
 FROM registry.access.redhat.com/ubi8/ubi
 
-LABEL vendor=Sonatype \
+LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <cloud-ops@sonatype.com>" \
+      vendor=Sonatype \
+      version="3.18.1-01" \
+      release="3.18.1" \
+      url="https://sonatype.com" \
+      summary="The Nexus Repository Manager server \
+          with universal support for popular component formats." \
+      description="The Nexus Repository Manager server \
+          with universal support for popular component formats." \
+      run="docker run -d --name NAME \
+          -p 8081:8081 \
+          IMAGE" \
+      stop="docker stop NAME" \
       com.sonatype.license="Apache License, Version 2.0" \
-      com.sonatype.name="Nexus Repository Manager base image"
+      com.sonatype.name="Nexus Repository Manager base image" \
+      io.k8s.description="The Nexus Repository Manager server \
+          with universal support for popular component formats." \
+      io.k8s.display-name="Nexus Repository Manager" \
+      io.openshift.expose-services="8081:8081" \
+      io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
 ARG NEXUS_VERSION=3.18.1-01
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/nexus-${NEXUS_VERSION}-unix.tar.gz

--- a/Dockerfile.rh.centos
+++ b/Dockerfile.rh.centos
@@ -14,9 +14,8 @@
 
 FROM centos:centos7
 
-MAINTAINER Sonatype <cloud-ops@sonatype.com>
-
 LABEL name="Nexus Repository Manager" \
+      maintainer="Sonatype <cloud-ops@sonatype.com>" \
       vendor=Sonatype \
       version="3.18.1-01" \
       release="3.18.1" \

--- a/Dockerfile.rh.el
+++ b/Dockerfile.rh.el
@@ -14,9 +14,8 @@
 
 FROM registry.access.redhat.com/rhel7/rhel
 
-MAINTAINER Sonatype <cloud-ops@sonatype.com>
-
 LABEL name="Nexus Repository Manager" \
+      maintainer="Sonatype <cloud-ops@sonatype.com>" \
       vendor=Sonatype \
       version="3.18.1-01" \
       release="3.18.1" \


### PR DESCRIPTION
This pull request makes the following changes:
* Merge MAINTAINER metadata into LABEL to reduce layers for the Centos and RHEL Dockerfiles
* Populate LABEL for the base Dockerfile with metadata found in Centos & RHEL

Closed out #112 which was against a separate branch and replaced with this PR against master branch.