### PR TITLE
cloud-ops email -> support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 FROM registry.access.redhat.com/ubi8/ubi
 
 LABEL name="Nexus Repository Manager" \
-      maintainer="Sonatype <cloud-ops@sonatype.com>" \
+      maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
       version="3.22.1-02" \
       release="3.22.1" \

--- a/Dockerfile.rh.centos
+++ b/Dockerfile.rh.centos
@@ -15,7 +15,7 @@
 FROM centos:centos7
 
 LABEL name="Nexus Repository Manager" \
-      maintainer="Sonatype <cloud-ops@sonatype.com>" \
+      maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
       version="3.22.1-02" \
       release="3.22.1" \

--- a/Dockerfile.rh.el
+++ b/Dockerfile.rh.el
@@ -15,7 +15,7 @@
 FROM registry.access.redhat.com/rhel7/rhel
 
 LABEL name="Nexus Repository Manager" \
-      maintainer="Sonatype <cloud-ops@sonatype.com>" \
+      maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
       version="3.22.1-02" \
       release="3.22.1" \

--- a/Dockerfile.rh.ubi
+++ b/Dockerfile.rh.ubi
@@ -16,7 +16,7 @@ FROM registry.access.redhat.com/ubi8/ubi
 
 LABEL name="Nexus Repository Manager" \
       vendor=Sonatype \
-      maintainer="Sonatype <cloud-ops@sonatype.com>" \
+      maintainer="Sonatype <support@sonatype.com>" \
       version="3.22.1-02" \
       release="3.22.1" \
       url="https://sonatype.com" \


### PR DESCRIPTION
cloud-ops email didn't really exist, so switch it to support@sonatype.com.