### PR TITLE
INT-2562 resilience for red hat trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ properties([
     string(defaultValue: '', description: 'New Nexus Repository Manager Cookbook Version', name: 'nexus_repository_manager_cookbook_version'),
     booleanParam(defaultValue: false, description: 'Skip Pushing of Docker Image and Tags', name: 'skip_push'),
     booleanParam(defaultValue: false, description: 'Force Red Hat Certified Build for a non-master branch', name: 'force_red_hat_build'),
+    booleanParam(defaultValue: false, description: 'Skip Red Hat Certified Build', name: 'skip_red_hat_build'),
   ])
 ])
 
@@ -174,7 +175,7 @@ node('ubuntu-zion') {
         OsTools.runSafe(this, "git tag -d ${version}")
       }
     }
-    if (branch == 'master' || params.force_red_hat_build) {
+    if ((! params.skip_red_hat_build) && (branch == 'master' || params.force_red_hat_build)) {
       stage('Trigger Red Hat Certified Image Build') {
         withCredentials([
             string(credentialsId: 'docker-nexus3-rh-build-project-id', variable: 'PROJECT_ID'),

--- a/ci/TriggerRedHatBuild.groovy
+++ b/ci/TriggerRedHatBuild.groovy
@@ -145,12 +145,17 @@ class BuildClient {
       println 'Waiting for build to finish.'
       sleep 60000
 
-      final completedBuild = getTags().find {
-        it.name == nextTag && it.scan_status == 'passed'
-      }
+      try {
+        final completedBuild = getTags().find {
+          it.name == nextTag && it.scan_status == 'passed'
+        }
 
-      if (completedBuild) {
-        return completedBuild
+        if (completedBuild) {
+          return completedBuild
+        }
+      } catch (HttpException ex) {
+        ex.printStackTrace()
+        System.err.println "Failed waiting for compleet build, but still retrying: ${ex.statusCode} [${ex.body}]"
       }
     }
 

--- a/ci/TriggerRedHatBuild.groovy
+++ b/ci/TriggerRedHatBuild.groovy
@@ -156,7 +156,7 @@ class BuildClient {
         }
       } catch (HttpException ex) {
         ex.printStackTrace()
-        System.err.println "Failed waiting for complete build, but still retrying: ${ex.statusCode} [${ex.body}]"
+        System.err.println "Failed retrieving completed builds, but still trying: ${ex.statusCode} [${ex.body}]"
       }
     }
 

--- a/ci/TriggerRedHatBuild.groovy
+++ b/ci/TriggerRedHatBuild.groovy
@@ -155,7 +155,7 @@ class BuildClient {
         }
       } catch (HttpException ex) {
         ex.printStackTrace()
-        System.err.println "Failed waiting for compleet build, but still retrying: ${ex.statusCode} [${ex.body}]"
+        System.err.println "Failed waiting for complete build, but still retrying: ${ex.statusCode} [${ex.body}]"
       }
     }
 

--- a/ci/TriggerRedHatBuild.groovy
+++ b/ci/TriggerRedHatBuild.groovy
@@ -14,7 +14,8 @@ import groovyx.net.http.HttpBuilder
 import groovyx.net.http.HttpException
 
 if (args.size() < 3) {
-  fail('Usage: groovy TriggerRedhatBuild.groovy <version> <projectId> <apiKey>')
+  System.err.println('Usage: groovy TriggerRedhatBuild.groovy <version> <projectId> <apiKey>')
+  System.exit(1)
 }
 
 new BuildClient(*args).run()


### PR DESCRIPTION
1. allow red hat builds to be skipped in case the service is down
2. retry on failure of service while watching for build to finish.

JIRA: https://issues.sonatype.org/browse/INT-2562
