### PR TITLE
Added stop_grace_period to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "nexus-data:/nexus-data"
     ports:
       - "8081:8081"
+    stop_grace_period: 2m
   
 volumes:
   nexus-data: {}


### PR DESCRIPTION
Added stop_grace_period to the docker-compose.yml to set the container's "StopTimeout" value to 120, as recommended by the readme.

