### PR TITLE
NEXUS-27617: Using new chef recipe that doesn't include java management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
     NEXUS_DATA=/nexus-data \
     NEXUS_CONTEXT='' \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \
-    DOCKER_TYPE='rh-docker'
+    DOCKER_TYPE='3x-docker'
 
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20190212-155606.d1afdfe"
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexus-repository-manager/releases/download/${NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION}/chef-nexus-repository-manager.tar.gz"
@@ -67,6 +67,10 @@ RUN yum install -y --disableplugin=subscription-manager hostname procps \
     && rm -rf /var/cache/yum \
     && rm -rf /var/chef \
     && yum clean all
+    
+# download and install openjdk 8
+RUN curl -O https://vault.centos.org/8.3.2011/AppStream/x86_64/os/Packages/java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64.rpm
+RUN yum localinstall -y --disableplugin=subscription-manager java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64.rpm
 
 VOLUME ${NEXUS_DATA}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \
     DOCKER_TYPE='3x-docker'
 
-ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20190212-155606.d1afdfe"
+ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20210628-162332.70a6cb6"
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexus-repository-manager/releases/download/${NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION}/chef-nexus-repository-manager.tar.gz"
 
 ADD solo.json.erb /var/chef/solo.json.erb

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,9 @@ RUN yum install -y --disableplugin=subscription-manager hostname procps \
     && yum clean all
     
 # download and install openjdk 8
-RUN curl -O https://vault.centos.org/8.3.2011/AppStream/x86_64/os/Packages/java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64.rpm
-RUN yum localinstall -y --disableplugin=subscription-manager java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64.rpm
+RUN curl -O https://vault.centos.org/8.3.2011/AppStream/x86_64/os/Packages/java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64.rpm \
+    && yum localinstall -y --disableplugin=subscription-manager java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64.rpm \
+    && rm -rf java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64.rpm
 
 VOLUME ${NEXUS_DATA}
 


### PR DESCRIPTION
To get onto openjdk 8u282 we need to manually deal with java, as 282 is no longer the latest bulid, and the current (292) has a bug that is causing SAML to not function (fix is in 302 which is still in EA)

This pull request makes the following changes:
* Switched to the new 3x-docker chef recipe (which has no java recipe)
* Manually download/install the 8u282 openjdk build

This PR depends on https://github.com/sonatype/chef-nexus-repository-manager/pull/59