### PR TITLE
disable red hat trigger until the script is corrected

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,6 +175,7 @@ node('ubuntu-zion') {
         OsTools.runSafe(this, "git tag -d ${version}")
       }
     }
+    /*
     if ((! params.skip_red_hat_build) && (branch == 'master' || params.force_red_hat_build)) {
       stage('Trigger Red Hat Certified Image Build') {
         withCredentials([
@@ -185,6 +186,7 @@ node('ubuntu-zion') {
         }
       }
     }
+    */
   } finally {
     OsTools.runSafe(this, "docker logout")
     OsTools.runSafe(this, "docker system prune -a -f")


### PR DESCRIPTION
the script to trigger the red hat build service is broken, and will soon be updated. in the meantime, disable it, so it doesn't fail the build for the plain docker image.


JIRA: https://issues.sonatype.org/browse/INT-5543
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/docker-nexus3-feature/job/INT-5543-disable-redhat/