### PR TITLE
remove volume definition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,6 @@ RUN curl -O https://vault.centos.org/8.3.2011/AppStream/x86_64/os/Packages/java-
     && yum localinstall -y --disableplugin=subscription-manager java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64.rpm \
     && rm -rf java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64.rpm
 
-VOLUME ${NEXUS_DATA}
-
 EXPOSE 8081
 USER nexus
 

--- a/Dockerfile.rh.centos
+++ b/Dockerfile.rh.centos
@@ -67,8 +67,6 @@ RUN curl -L https://omnitruck.chef.io/install.sh | bash \
     && rm -rf /var/cache/yum \
     && rm -rf /var/chef
 
-VOLUME ${NEXUS_DATA}
-
 EXPOSE 8081
 USER nexus
 

--- a/Dockerfile.rh.el
+++ b/Dockerfile.rh.el
@@ -67,8 +67,6 @@ RUN curl -L https://omnitruck.chef.io/install.sh | bash \
     && rm -rf /var/cache/yum \
     && rm -rf /var/chef
 
-VOLUME ${NEXUS_DATA}
-
 EXPOSE 8081
 USER nexus
 

--- a/Dockerfile.rh.ubi
+++ b/Dockerfile.rh.ubi
@@ -68,8 +68,6 @@ RUN curl -L https://omnitruck.chef.io/install.sh | bash -s -- -v 14.12.9 \
     && rm -rf /var/chef \
     && yum clean all
 
-VOLUME ${NEXUS_DATA}
-
 EXPOSE 8081
 USER nexus
 


### PR DESCRIPTION
Remove any volume definition in the dockerfiles, to make it possible to set a fixed Nexus environment on the docker-build. Use-case is to use Nexus as a cache instance for local Kubernetes environment (see [forum post](https://community.sonatype.com/t/nexus-as-cache-for-kubenetes-kind/7955))

This pull request makes the following changes:

* remove `VOLUME` line in all dockerfiles, so removing volume creation only
