### PR TITLE
Add environment variable to override admin password

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,5 +34,6 @@ External contributors:
 
 * [@bestlong](https://github.com/bestlong/) (Yu-Lung Shao (Allen))
 * [@jperville](https://github.com/jperville/) (Julien Pervillé)
+* [@leroyguillaume](https://github.com/leroyguillaume) (Guillaume Leroy)
 
 ![Possibly You!](http://i.imgur.com/A3eScYul.jpg)

--- a/Dockerfile.rh.centos
+++ b/Dockerfile.rh.centos
@@ -39,6 +39,7 @@ LABEL name="Nexus Repository Manager" \
 ARG NEXUS_VERSION=3.37.3-02
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/nexus-${NEXUS_VERSION}-unix.tar.gz
 ARG NEXUS_DOWNLOAD_SHA256_HASH=c1db431908c5a76b44015c555d6ef4517abf0a86844faffee0f5d6c62359312d
+ARG SHIRO_VERSION=1.8.0
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype
@@ -46,7 +47,8 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
     NEXUS_DATA=/nexus-data \
     NEXUS_CONTEXT='' \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \
-    DOCKER_TYPE='rh-docker'
+    DOCKER_TYPE='rh-docker' \
+    SHIRO_CLI_JAR=/opt/shiro-tools-hasher-${SHIRO_VERSION}-cli.jar
 
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20190212-155606.d1afdfe"
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexus-repository-manager/releases/download/${NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION}/chef-nexus-repository-manager.tar.gz"
@@ -67,6 +69,13 @@ RUN curl -L https://omnitruck.chef.io/install.sh | bash \
     && rm -rf /var/cache/yum \
     && rm -rf /var/chef
 
+# download and install shiro cli
+RUN curl -L https://repo1.maven.org/maven2/org/apache/shiro/tools/shiro-tools-hasher/${SHIRO_VERSION}/shiro-tools-hasher-${SHIRO_VERSION}-cli.jar > ${SHIRO_CLI_JAR}
+
+# copy entrypoint script
+COPY entrypoint.sh ${SONATYPE_DIR}/entrypoint.sh
+RUN chmod 0755 ${SONATYPE_DIR}/entrypoint.sh
+
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081
@@ -75,4 +84,4 @@ USER nexus
 ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
 
 ENTRYPOINT ["/uid_entrypoint.sh"]
-CMD ["sh", "-c", "${SONATYPE_DIR}/start-nexus-repository-manager.sh"]
+CMD ["sh", "-c", "${SONATYPE_DIR}/entrypoint.sh"]

--- a/Dockerfile.rh.el
+++ b/Dockerfile.rh.el
@@ -39,6 +39,7 @@ LABEL name="Nexus Repository Manager" \
 ARG NEXUS_VERSION=3.37.3-02
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/nexus-${NEXUS_VERSION}-unix.tar.gz
 ARG NEXUS_DOWNLOAD_SHA256_HASH=c1db431908c5a76b44015c555d6ef4517abf0a86844faffee0f5d6c62359312d
+ARG SHIRO_VERSION=1.8.0
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype
@@ -46,7 +47,8 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
     NEXUS_DATA=/nexus-data \
     NEXUS_CONTEXT='' \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \
-    DOCKER_TYPE='rh-docker'
+    DOCKER_TYPE='rh-docker' \
+    SHIRO_CLI_JAR=/opt/shiro-tools-hasher-${SHIRO_VERSION}-cli.jar
 
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20190212-155606.d1afdfe"
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexus-repository-manager/releases/download/${NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION}/chef-nexus-repository-manager.tar.gz"
@@ -67,6 +69,13 @@ RUN curl -L https://omnitruck.chef.io/install.sh | bash \
     && rm -rf /var/cache/yum \
     && rm -rf /var/chef
 
+# download and install shiro cli
+RUN curl -L https://repo1.maven.org/maven2/org/apache/shiro/tools/shiro-tools-hasher/${SHIRO_VERSION}/shiro-tools-hasher-${SHIRO_VERSION}-cli.jar > ${SHIRO_CLI_JAR}
+
+# copy entrypoint script
+COPY entrypoint.sh ${SONATYPE_DIR}/entrypoint.sh
+RUN chmod 0755 ${SONATYPE_DIR}/entrypoint.sh
+
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081
@@ -75,4 +84,4 @@ USER nexus
 ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
 
 ENTRYPOINT ["/uid_entrypoint.sh"]
-CMD ["sh", "-c", "${SONATYPE_DIR}/start-nexus-repository-manager.sh"]
+CMD ["sh", "-c", "${SONATYPE_DIR}/entrypoint.sh"]

--- a/Dockerfile.rh.ubi
+++ b/Dockerfile.rh.ubi
@@ -39,6 +39,7 @@ LABEL name="Nexus Repository Manager" \
 ARG NEXUS_VERSION=3.37.3-02
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/nexus-${NEXUS_VERSION}-unix.tar.gz
 ARG NEXUS_DOWNLOAD_SHA256_HASH=c1db431908c5a76b44015c555d6ef4517abf0a86844faffee0f5d6c62359312d
+ARG SHIRO_VERSION=1.8.0
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype
@@ -46,7 +47,8 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
     NEXUS_DATA=/nexus-data \
     NEXUS_CONTEXT='' \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \
-    DOCKER_TYPE='rh-docker'
+    DOCKER_TYPE='rh-docker' \
+    SHIRO_CLI_JAR=/opt/shiro-tools-hasher-${SHIRO_VERSION}-cli.jar
 
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20190212-155606.d1afdfe"
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexus-repository-manager/releases/download/${NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION}/chef-nexus-repository-manager.tar.gz"
@@ -68,6 +70,13 @@ RUN curl -L https://omnitruck.chef.io/install.sh | bash -s -- -v 14.12.9 \
     && rm -rf /var/chef \
     && yum clean all
 
+# download and install shiro cli
+RUN curl -L https://repo1.maven.org/maven2/org/apache/shiro/tools/shiro-tools-hasher/${SHIRO_VERSION}/shiro-tools-hasher-${SHIRO_VERSION}-cli.jar > ${SHIRO_CLI_JAR}
+
+# copy entrypoint script
+COPY entrypoint.sh ${SONATYPE_DIR}/entrypoint.sh
+RUN chmod 0755 ${SONATYPE_DIR}/entrypoint.sh
+
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081
@@ -76,4 +85,4 @@ USER nexus
 ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
 
 ENTRYPOINT ["/uid_entrypoint.sh"]
-CMD ["sh", "-c", "${SONATYPE_DIR}/start-nexus-repository-manager.sh"]
+CMD ["sh", "-c", "${SONATYPE_DIR}/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ process, which runs as UID 200.
   $ docker run -d -p 8081:8081 --name nexus -e NEXUS_CONTEXT=nexus sonatype/nexus3
   ```
 
+* You can set admin initial password by using `NEXUS_ADMIN_INIT_PASSWORD` environment variable
+
 ### Persistent Data
 
 There are two general approaches to handling persistent storage requirements

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -z "${NEXUS_ADMIN_INIT_PASSWORD}" ] || [ -d "${SONATYPE_WORK}/nexus3/db/security" ]; then
+    ${SONATYPE_DIR}/start-nexus-repository-manager.sh
+else
+    SHIRO_PASSWORD=$(java -jar "${SHIRO_CLI_JAR}" -a SHA-512 -f shiro1 "${NEXUS_ADMIN_INIT_PASSWORD}")
+    "${SONATYPE_DIR}/start-nexus-repository-manager.sh" &
+    while ! curl -f localhost:8081 > /dev/null 2>&1; do
+        sleep 1
+    done
+    NEXUS_PID=$(ps aux | grep nexus | grep -v grep | awk '{print $2}')
+    kill $NEXUS_PID
+    java -jar ${SONATYPE_DIR}/nexus/lib/support/nexus-orient-console.jar "connect plocal:${SONATYPE_WORK}/nexus3/db/security admin admin; update user SET password=\"${SHIRO_PASSWORD}\", status=\"active\" UPSERT WHERE id=\"admin\""
+    "${SONATYPE_DIR}/start-nexus-repository-manager.sh"
+fi


### PR DESCRIPTION
Add new environment variable `NEXUS_ADMIN_INIT_PASSWORD` to override admin password at the first Nexus start.

If this variable is set, the Nexus start a first time to initialize its files. Once started, it is stopped and the security Orient database is updated. The hash of the password is generated by Apache Shiro CLI. Then, Nexus is restarted.
