### PR TITLE
Latest Chef Recipes and Latest Java 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \
     DOCKER_TYPE='rh-docker'
 
-ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20210628-162332.70a6cb6"
+ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20220111-153152.2b86c3a"
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexus-repository-manager/releases/download/${NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION}/chef-nexus-repository-manager.tar.gz"
 
 ADD solo.json.erb /var/chef/solo.json.erb

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
     NEXUS_DATA=/nexus-data \
     NEXUS_CONTEXT='' \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \
-    DOCKER_TYPE='3x-docker'
+    DOCKER_TYPE='rh-docker'
 
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20210628-162332.70a6cb6"
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexus-repository-manager/releases/download/${NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION}/chef-nexus-repository-manager.tar.gz"
@@ -68,11 +68,6 @@ RUN yum install -y --disableplugin=subscription-manager hostname procps \
     && rm -rf /var/chef \
     && yum clean all
     
-# download and install openjdk 8
-RUN curl -O https://vault.centos.org/8.3.2011/AppStream/x86_64/os/Packages/java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64.rpm \
-    && yum localinstall -y --disableplugin=subscription-manager java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64.rpm \
-    && rm -rf java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64.rpm
-
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081

--- a/Dockerfile.rh.centos
+++ b/Dockerfile.rh.centos
@@ -48,13 +48,13 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \
     DOCKER_TYPE='rh-docker'
 
-ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20190212-155606.d1afdfe"
+ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20220111-153152.2b86c3a"
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexus-repository-manager/releases/download/${NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION}/chef-nexus-repository-manager.tar.gz"
 
 ADD solo.json.erb /var/chef/solo.json.erb
 
 # Install using chef-solo
-RUN curl -L https://omnitruck.chef.io/install.sh | bash \
+RUN curl -L https://omnitruck.chef.io/install.sh | bash -s -- -v 14.12.9 \
     && /opt/chef/embedded/bin/erb /var/chef/solo.json.erb > /var/chef/solo.json \
     && chef-solo \
        --node_name nexus_repository_red_hat_docker_build \

--- a/Dockerfile.rh.ubi
+++ b/Dockerfile.rh.ubi
@@ -48,7 +48,7 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \
     DOCKER_TYPE='rh-docker'
 
-ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20190212-155606.d1afdfe"
+ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION="release-0.5.20220111-153152.2b86c3a"
 ARG NEXUS_REPOSITORY_MANAGER_COOKBOOK_URL="https://github.com/sonatype/chef-nexus-repository-manager/releases/download/${NEXUS_REPOSITORY_MANAGER_COOKBOOK_VERSION}/chef-nexus-repository-manager.tar.gz"
 
 ADD solo.json.erb /var/chef/solo.json.erb


### PR DESCRIPTION
Java in the main image was pinned at an older version about a 9 months ago for a bug in java (https://issues.sonatype.org/browse/NEXUS-27617, previous PR I'm partially undoing: https://github.com/sonatype/docker-nexus3/pull/129). It was fixed in the 302 build (https://bugs.openjdk.java.net/browse/JDK-8267766), so this can go back to the way it was. I think the `docker-3x` recipe in the chef repo could go away as well, since this is no longer using it.

Also, the chef recipe hasn't been updated in a while. The Red Hat images were left even more out of date since before the pinning of the JVM. I'm finding the Dockerfile.rh.el file for RHEL7 to be unbuildable, since it's saying there's no openjdk 8 candidate available there, so I've not touched that one. I know I only have direct use for the Dockerfile and Dockerfile.rh.ubi builds. I'm not sure how important the other 2 Dockerfile.rh.* files are.

A security report on artifacthub got me interested in seeing why this image still had an older java 8. https://artifacthub.io/packages/helm/sonatype/nexus-repository-manager?modal=security-report&image=sonatype%2Fnexus3%3A3.38.1&target=sonatype%2Fnexus3%3A3.38.1%20(redhat%208.5)

Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/docker-nexus3-feature/job/back-to-latest-rh-recipe/