### PR TITLE
NEXUS-34767 - Remove chef and switch to ubi8/ubi-minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,9 @@ RUN curl -L ${NEXUS_DOWNLOAD_URL} | tar -xz \
     && mv nexus-${NEXUS_VERSION} $NEXUS_HOME \
     && groupadd --gid 200 -r nexus \
     && useradd --uid 200 -r nexus -g nexus \
-    && chown -R nexus:nexus ${SONATYPE_WORK} \
-    && mkdir ${NEXUS_DATA} \
-    && chown -R nexus:nexus ${NEXUS_DATA}
+    && mv ${SONATYPE_WORK}/nexus3 ${NEXUS_DATA} \
+    && ln -s ${NEXUS_DATA} ${SONATYPE_WORK}/nexus3 \
+    && chown -R nexus:nexus ${SONATYPE_WORK}
 
 VOLUME ${NEXUS_DATA}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,10 @@ RUN curl -L ${NEXUS_DOWNLOAD_URL} --output nexus-${NEXUS_VERSION}-unix.tar.gz \
     && mv ${SONATYPE_WORK}/nexus3 ${NEXUS_DATA} \
     && ln -s ${NEXUS_DATA} ${SONATYPE_WORK}/nexus3
 
+RUN echo "#!/bin/sh" >> ${SONATYPE_DIR}/start-nexus-repository-manager.sh \
+   && echo "/opt/sonatype/nexus/bin/nexus run" >> ${SONATYPE_DIR}/start-nexus-repository-manager.sh \
+   && chmod a+x ${SONATYPE_DIR}/start-nexus-repository-manager.sh
+
 RUN microdnf remove -y tar gzip shadow-utils
 
 VOLUME ${NEXUS_DATA}

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN microdnf update -y \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
           java-1.8.0-openjdk-headless tar procps shadow-utils gzip \
     && microdnf clean all \
-    && groupadd -r nexus \
+    && groupadd --gid 200 -r nexus \
     && useradd --uid 200 -r nexus -g nexus
 
 WORKDIR ${SONATYPE_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,11 @@ RUN microdnf update -y \
 WORKDIR ${SONATYPE_DIR}
 
 # Download nexus & setup directories
-RUN curl -L ${NEXUS_DOWNLOAD_URL} | tar -xz \
+RUN curl -L ${NEXUS_DOWNLOAD_URL} --output nexus-${NEXUS_VERSION}-unix.tar.gz \
+    && echo "${NEXUS_DOWNLOAD_SHA256_HASH} nexus-${NEXUS_VERSION}-unix.tar.gz" > nexus-${NEXUS_VERSION}-unix.tar.gz.sha256 \
+    && sha256sum -c nexus-${NEXUS_VERSION}-unix.tar.gz.sha256 \
+    && tar -xvf nexus-${NEXUS_VERSION}-unix.tar.gz \
+    && rm -f nexus-${NEXUS_VERSION}-unix.tar.gz nexus-${NEXUS_VERSION}-unix.tar.gz.sha256 \
     && mv nexus-${NEXUS_VERSION} $NEXUS_HOME \
     && chown -R nexus:nexus ${SONATYPE_WORK} \
     && mv ${SONATYPE_WORK}/nexus3 ${NEXUS_DATA} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
@@ -50,7 +50,8 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
 
 # Install Java & tar
 RUN microdnf update -y \
-    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless tar procps \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
+          java-1.8.0-openjdk-headless tar procps shadow-utils gzip \
     && microdnf clean all \
     && groupadd -r nexus \
     && useradd --uid 200 -r nexus -g nexus
@@ -67,6 +68,8 @@ RUN curl -L ${NEXUS_DOWNLOAD_URL} --output nexus-${NEXUS_VERSION}-unix.tar.gz \
     && chown -R nexus:nexus ${SONATYPE_WORK} \
     && mv ${SONATYPE_WORK}/nexus3 ${NEXUS_DATA} \
     && ln -s ${NEXUS_DATA} ${SONATYPE_WORK}/nexus3
+
+RUN microdnf remove -y tar gzip shadow-utils
 
 VOLUME ${NEXUS_DATA}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
 
 # Install Java & tar
 RUN microdnf update -y \
-    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless tar \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless tar procps \
     && microdnf clean all \
     && groupadd --gid 200 -r nexus \
     && useradd --uid 200 -r nexus -g nexus

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
 RUN microdnf update -y \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless tar procps \
     && microdnf clean all \
-    && groupadd --gid 200 -r nexus \
+    && groupadd -r nexus \
     && useradd --uid 200 -r nexus -g nexus
 
 WORKDIR ${SONATYPE_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,14 +50,14 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
 
 RUN microdnf update -y \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-1.8.0-openjdk-headless tar \
-    && microdnf clean all
+    && microdnf clean all \
+    && groupadd --gid 200 -r nexus \
+    && useradd --uid 200 -r nexus -g nexus
 
 WORKDIR ${SONATYPE_DIR}
 
 RUN curl -L ${NEXUS_DOWNLOAD_URL} | tar -xz \
     && mv nexus-${NEXUS_VERSION} $NEXUS_HOME \
-    && groupadd --gid 200 -r nexus \
-    && useradd --uid 200 -r nexus -g nexus \
     && mv ${SONATYPE_WORK}/nexus3 ${NEXUS_DATA} \
     && ln -s ${NEXUS_DATA} ${SONATYPE_WORK}/nexus3 \
     && chown -R nexus:nexus ${SONATYPE_WORK}

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,4 +75,4 @@ USER nexus
 
 ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
 
-ENTRYPOINT ["/opt/sonatype/nexus/bin/nexus", "run"]
+CMD ["/opt/sonatype/nexus/bin/nexus", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,10 @@ RUN curl -L ${NEXUS_DOWNLOAD_URL} | tar -xz \
     && ln -s ${NEXUS_DATA} ${SONATYPE_WORK}/nexus3 \
     && chown -R nexus:nexus ${SONATYPE_WORK}
 
+RUN echo "cd ${SONATYPE_DIR}" >> ${SONATYPE_DIR}/start.sh \
+    && echo "./nexus/bin/nexus run" >> ${SONATYPE_DIR}/start.sh \
+    && chmod a+x ${SONATYPE_DIR}/start.sh
+
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081
@@ -69,4 +73,4 @@ USER nexus
 
 ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
 
-CMD ["sh", "-c", "${NEXUS_HOME}/bin/nexus run"]
+CMD ["sh", "/opt/sonatype/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN microdnf update -y \
           java-1.8.0-openjdk-headless tar procps shadow-utils gzip \
     && microdnf clean all \
     && groupadd --gid 200 -r nexus \
-    && useradd --uid 200 -r nexus -g nexus
+    && useradd --uid 200 -r nexus -g nexus -s /bin/false -d /opt/sonatype/nexus -c 'Nexus Repository Manager user'
 
 WORKDIR ${SONATYPE_DIR}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,9 @@ RUN curl -L ${NEXUS_DOWNLOAD_URL} --output nexus-${NEXUS_VERSION}-unix.tar.gz \
     && mv ${SONATYPE_WORK}/nexus3 ${NEXUS_DATA} \
     && ln -s ${NEXUS_DATA} ${SONATYPE_WORK}/nexus3
 
-RUN echo "#!/bin/sh" >> ${SONATYPE_DIR}/start-nexus-repository-manager.sh \
-   && echo "/opt/sonatype/nexus/bin/nexus run" >> ${SONATYPE_DIR}/start-nexus-repository-manager.sh \
+RUN echo "#!/bin/bash" >> ${SONATYPE_DIR}/start-nexus-repository-manager.sh \
+   && echo "cd /opt/sonatype/nexus" >> ${SONATYPE_DIR}/start-nexus-repository-manager.sh \
+   && echo "exec ./bin/nexus run" >> ${SONATYPE_DIR}/start-nexus-repository-manager.sh \
    && chmod a+x ${SONATYPE_DIR}/start-nexus-repository-manager.sh
 
 RUN microdnf remove -y tar gzip shadow-utils

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ WORKDIR ${SONATYPE_DIR}
 
 RUN curl -L ${NEXUS_DOWNLOAD_URL} | tar -xz \
     && mv nexus-${NEXUS_VERSION} $NEXUS_HOME \
-    && groupadd -r nexus \
-    && useradd -r nexus -g nexus \
+    && groupadd --gid 200 -r nexus \
+    && useradd --uid 200 -r nexus -g nexus \
     && chown -R nexus:nexus ${SONATYPE_WORK} \
     && mkdir ${NEXUS_DATA} \
     && chown -R nexus:nexus ${NEXUS_DATA}


### PR DESCRIPTION
Removes the usage of Chef from the creation of the image, and switches to `ubi9/ubi-minimal` from `ubi8/ubi` to reduce the amount of cruft in the image.
