### PR TITLE
IDay: Update Jenkinsfiles to use new 'main' default branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ node('ubuntu-zion') {
 
       def checkoutDetails = checkout scm
 
-      branch = checkoutDetails.GIT_BRANCH == 'origin/master' ? 'master' : checkoutDetails.GIT_BRANCH
+      branch = checkoutDetails.GIT_BRANCH == 'origin/main' ? 'main' : checkoutDetails.GIT_BRANCH
       commitId = checkoutDetails.GIT_COMMIT
       commitDate = OsTools.runSafe(this, "git show -s --format=%cd --date=format:%Y%m%d-%H%M%S ${commitId}")
 
@@ -77,7 +77,7 @@ node('ubuntu-zion') {
           iqApplication: 'docker-nexus3',
           iqScanPatterns: [[scanPattern: "container:${imageName}"]],
           failBuildOnNetworkError: true,
-        )}, (branch == 'master') ? 'build' : 'develop')
+        )}, (branch == 'main') ? 'build' : 'develop')
     }
 
     if (currentBuild.result == 'FAILURE') {
@@ -93,7 +93,7 @@ node('ubuntu-zion') {
   } finally {
     OsTools.runSafe(this, 'docker logout')
     OsTools.runSafe(this, 'docker system prune -a -f')
-    OsTools.runSafe(this, 'git clean -f && git reset --hard origin/master')
+    OsTools.runSafe(this, 'git clean -f && git reset --hard origin/main')
   }
 }
 

--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -41,7 +41,7 @@ node('ubuntu-zion') {
         "${pwd()}/Dockerfile.rh.ubi"
       ]
 
-      branch = checkoutDetails.GIT_BRANCH == 'origin/master' ? 'master' : checkoutDetails.GIT_BRANCH
+      branch = checkoutDetails.GIT_BRANCH == 'origin/main' ? 'main' : checkoutDetails.GIT_BRANCH
       commitId = checkoutDetails.GIT_COMMIT
       commitDate = OsTools.runSafe(this, "git show -s --format=%cd --date=format:%Y%m%d-%H%M%S ${commitId}")
 
@@ -144,7 +144,7 @@ node('ubuntu-zion') {
         archiveArtifacts artifacts: "${archiveName}.tar.gz", onlyIfSuccessful: true
       }
     }
-    if (branch == 'master' && !params.skip_push && !params.update_latest_only) {
+    if (branch == 'main' && !params.skip_push && !params.update_latest_only) {
       input 'Push image and tags?'
       stage('Push image') {
         def dockerhubApiToken
@@ -203,7 +203,7 @@ node('ubuntu-zion') {
   } finally {
     OsTools.runSafe(this, "docker logout")
     OsTools.runSafe(this, "docker system prune -a -f")
-    OsTools.runSafe(this, 'git clean -f && git reset --hard origin/master')
+    OsTools.runSafe(this, 'git clean -f && git reset --hard origin/main')
   }
 }
 

--- a/Jenkinsfile.rh
+++ b/Jenkinsfile.rh
@@ -43,6 +43,6 @@ node('ubuntu-zion') {
   } finally {
     sh 'docker logout'
     sh 'docker system prune -a -f'
-    sh 'git clean -f && git reset --hard origin/master'
+    sh 'git clean -f && git reset --hard origin/main'
   }
 }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A Dockerfile for Sonatype Nexus Repository Manager 3, starting with 3.18 the ima
 
 ## Contribution Guidelines
 
-Go read [our contribution guidelines](https://github.com/sonatype/docker-nexus3/blob/master/.github/CONTRIBUTING.md) to get a bit more familiar with how
+Go read [our contribution guidelines](https://github.com/sonatype/docker-nexus3/blob/main/.github/CONTRIBUTING.md) to get a bit more familiar with how
 we would like things to flow.
 
 ## Running
@@ -60,7 +60,7 @@ $ curl http://localhost:8081/
 
 ## Building the Nexus Repository Manager image
 
-To build a docker image from the [Dockerfile](https://github.com/sonatype/docker-nexus3/blob/master/Dockerfile) you can use this command:
+To build a docker image from the [Dockerfile](https://github.com/sonatype/docker-nexus3/blob/main/Dockerfile) you can use this command:
 
 ```
 $ docker build --rm=true --tag=sonatype/nexus3 .
@@ -88,7 +88,7 @@ We are using `rspec` as the test framework. `serverspec` provides a docker backe
 
 ## Red Hat Certified Image
 
-A Red Hat certified container image can be created using [Dockerfile.rh.ubi](https://github.com/sonatype/docker-nexus3/blob/master/Dockerfile.rh.ubi) which is built to be compliant with Red Hat certification.
+A Red Hat certified container image can be created using [Dockerfile.rh.ubi](https://github.com/sonatype/docker-nexus3/blob/main/Dockerfile.rh.ubi) which is built to be compliant with Red Hat certification.
 The image includes additional meta data to comform with Kubernetes and OpenShift standards, a directory with the
 licenses applicable to the software and a man file for help on how to use the software. It also uses an ENTRYPOINT
 script the ensure the running user has access to the appropriate permissions for OpenShift 'restricted' SCC. 
@@ -100,8 +100,8 @@ and qualified accounts can pull it from registry.connect.redhat.com.
 ## Other Red Hat Images
 
 In addition to the Universal Base Image, we can build images based on:
-* Red Hat Enterprise Linux: [Dockerfile.rh.el](https://github.com/sonatype/docker-nexus3/blob/master/Dockerfile.rh.el)
-* CentOS: [Dockerfile.rh.centos](https://github.com/sonatype/docker-nexus3/blob/master/Dockerfile.rh.centos)
+* Red Hat Enterprise Linux: [Dockerfile.rh.el](https://github.com/sonatype/docker-nexus3/blob/main/Dockerfile.rh.el)
+* CentOS: [Dockerfile.rh.centos](https://github.com/sonatype/docker-nexus3/blob/main/Dockerfile.rh.centos)
 
 ## Notes
 


### PR DESCRIPTION
This pull request updates references to the default branch to now use 'main' instead of 'master'.

After it is merge, the default branch has to be changed in the repo, and the following Jenkins configuration must to be point to main branch:

https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/docker-nexus3/configure 
https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/docker-nexus3-feature/configure 
https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/docker-nexus3-master-snapshot/configure
