### PR TITLE
Don't pull image through here, the deployment job does that before deploying

### DIFF
--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -178,7 +178,6 @@ node('ubuntu-zion-legacy') {
           withSonatypeDockerRegistry() {
             sh "docker tag ${imageId} docker-all.repo.sonatype.com/sonatype-internal/${dockerHubRepository}:${version}"
             sh "docker push docker-all.repo.sonatype.com/sonatype-internal/${dockerHubRepository}:${version}"
-            sh "docker pull docker-internal.rsc-proxy.ci.sonatype.dev/sonatype-internal/${dockerHubRepository}:${version}"
           }
         }
       }


### PR DESCRIPTION
This job is still on the legacy agent which cannot authenticate to docker-internal.rsc-proxy  We pull the image through before attempting to deploy it anyway so we don't really need to do it here.

https://github.com/sonatype/nxrm-deploy/blob/c11892302ad562ef846bc7c062736281eb1165f9/release/Jenkinsfile.prod#L34
