### PR TITLE
Fix broken issue reporting link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ for additional information.
 Looking to contribute to our Docker image but need some help? There's a few ways to get information or our attention:
 
 * Chat with us on [Gitter](https://gitter.im/sonatype/nexus-developers)
-* File an issue [on our public JIRA](https://issues.sonatype.org/projects/NEXUS/)
+* File an issue [on the nexus-public GitHub repository](https://github.com/sonatype/nexus-public/issues)
 * Check out the [Nexus3](http://stackoverflow.com/questions/tagged/nexus3) tag on Stack Overflow
 * Check out the [Sonatype Nexus Repository User List](https://groups.google.com/a/glists.sonatype.com/forum/?hl=en#!forum/nexus-users)
 


### PR DESCRIPTION
This pull request makes the following changes:
* replaces the broken link for issue reporting to the now closed NEXUS JIRA with a link to nexus-public

It relates to the following issue #s:
* https://github.com/sonatype/nexus-public/issues/105
