### PR TITLE
NEXUS-40270 Publish docker release candidate image to internal repo

### DIFF
--- a/Dockerfile.release.candidate
+++ b/Dockerfile.release.candidate
@@ -1,0 +1,90 @@
+# Copyright (c) 2016-present Sonatype, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+LABEL name="Nexus Repository Manager" \
+      maintainer="Sonatype <support@sonatype.com>" \
+      vendor=Sonatype \
+      version="3.59.0-01" \
+      release="3.59.0" \
+      url="https://sonatype.com" \
+      summary="The Nexus Repository Manager server \
+          with universal support for popular component formats." \
+      description="The Nexus Repository Manager server \
+          with universal support for popular component formats." \
+      run="docker run -d --name NAME \
+          -p 8081:8081 \
+          IMAGE" \
+      stop="docker stop NAME" \
+      com.sonatype.license="Apache License, Version 2.0" \
+      com.sonatype.name="Nexus Repository Manager base image" \
+      io.k8s.description="The Nexus Repository Manager server \
+          with universal support for popular component formats." \
+      io.k8s.display-name="Nexus Repository Manager" \
+      io.openshift.expose-services="8081:8081" \
+      io.openshift.tags="Sonatype,Nexus,Repository Manager"
+
+ARG NEXUS_VERSION=3.59.0-01
+ARG NEXUS_DOWNLOAD_URL=https://download-staging.sonatype.com/nexus/3/nexus-${NEXUS_VERSION}-unix.tar.gz
+ARG NEXUS_DOWNLOAD_SHA256_HASH=19bc207fbf05e232d9c521e95cb7253e946a5e56521b828c4252a0b72f7262a8
+
+# configure nexus runtime
+ENV SONATYPE_DIR=/opt/sonatype
+ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
+    NEXUS_DATA=/nexus-data \
+    NEXUS_CONTEXT='' \
+    SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \
+    DOCKER_TYPE='rh-docker'
+
+# Install Java & tar
+RUN microdnf update -y \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
+          java-1.8.0-openjdk-headless tar procps shadow-utils gzip \
+    && microdnf clean all \
+    && groupadd --gid 200 -r nexus \
+    && useradd --uid 200 -r nexus -g nexus -s /bin/false -d /opt/sonatype/nexus -c 'Nexus Repository Manager user'
+
+WORKDIR ${SONATYPE_DIR}
+
+# Download nexus & setup directories
+RUN curl -L ${NEXUS_DOWNLOAD_URL} --output nexus-${NEXUS_VERSION}-unix.tar.gz \
+    && echo "${NEXUS_DOWNLOAD_SHA256_HASH} nexus-${NEXUS_VERSION}-unix.tar.gz" > nexus-${NEXUS_VERSION}-unix.tar.gz.sha256 \
+    && sha256sum -c nexus-${NEXUS_VERSION}-unix.tar.gz.sha256 \
+    && tar -xvf nexus-${NEXUS_VERSION}-unix.tar.gz \
+    && rm -f nexus-${NEXUS_VERSION}-unix.tar.gz nexus-${NEXUS_VERSION}-unix.tar.gz.sha256 \
+    && mv nexus-${NEXUS_VERSION} $NEXUS_HOME \
+    && chown -R nexus:nexus ${SONATYPE_WORK} \
+    && mv ${SONATYPE_WORK}/nexus3 ${NEXUS_DATA} \
+    && ln -s ${NEXUS_DATA} ${SONATYPE_WORK}/nexus3
+
+# Removing java memory settings from nexus.vmoptions since now we use INSTALL4J_ADD_VM_PARAMS
+RUN sed -i '/^-Xms/d;/^-Xmx/d;/^-XX:MaxDirectMemorySize/d' $NEXUS_HOME/bin/nexus.vmoptions
+
+RUN echo "#!/bin/bash" >> ${SONATYPE_DIR}/start-nexus-repository-manager.sh \
+   && echo "cd /opt/sonatype/nexus" >> ${SONATYPE_DIR}/start-nexus-repository-manager.sh \
+   && echo "exec ./bin/nexus run" >> ${SONATYPE_DIR}/start-nexus-repository-manager.sh \
+   && chmod a+x ${SONATYPE_DIR}/start-nexus-repository-manager.sh \
+   && sed -e '/^nexus-context/ s:$:${NEXUS_CONTEXT}:' -i ${NEXUS_HOME}/etc/nexus-default.properties
+
+RUN microdnf remove -y gzip shadow-utils
+
+VOLUME ${NEXUS_DATA}
+
+EXPOSE 8081
+USER nexus
+
+ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
+
+CMD ["/opt/sonatype/nexus/bin/nexus", "run"]

--- a/Jenkinsfile-Release-candidate
+++ b/Jenkinsfile-Release-candidate
@@ -13,7 +13,7 @@ properties([
     string(defaultValue: '', description: 'New Nexus Repository Manager Version', name: 'nexus_repository_manager_version'),
     string(defaultValue: '', description: 'New Nexus Repository Manager Version Sha256', name: 'nexus_repository_manager_version_sha'),
     string(defaultValue: '', description: 'New Nexus Repository Manager URL', name: 'nexus_repository_manager_url'),
-    booleanParam(defaultValue: false, description: 'Optional scan for policy violations', name: 'scan_for_policy_violations'),
+    booleanParam(defaultValue: false, description: 'Optional scan for policy violations', name: '`scan_for_policy_violations`'),
     booleanParam(defaultValue: false, description: 'Skip Pushing of Docker Image and Tags', name: 'skip_push'),
   ])
 ])
@@ -162,7 +162,7 @@ def updateRepositoryManagerVersion(dockerFileLocation) {
   def versionRegex = /(ARG NEXUS_VERSION=)(\d\.\d{1,3}\.\d\-\d{2})/
   def shaRegex = /(ARG NEXUS_DOWNLOAD_SHA256_HASH=)([A-Fa-f0-9]{64})/
 
-  def nexusUrlRegex = /(ARG NEXUS_DOWNLOAD_URL=)(.*$)/
+  def nexusUrlRegex = /(ARG NEXUS_DOWNLOAD_URL=)(.*\$)/
 
   dockerFile = dockerFile.replaceAll(metaVersionRegex, "\$1${params.nexus_repository_manager_version}\$3")
   dockerFile = dockerFile.replaceAll(metaShortVersionRegex,

--- a/Jenkinsfile-Release-candidate
+++ b/Jenkinsfile-Release-candidate
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2016-present Sonatype, Inc. All rights reserved.
+ * Includes the third-party code listed at http://links.sonatype.com/products/nexus/attributions.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+@Library(['private-pipeline-library', 'jenkins-shared']) _
+import com.sonatype.jenkins.pipeline.GitHub
+import com.sonatype.jenkins.pipeline.OsTools
+import com.sonatype.jenkins.shared.Expectation
+
+properties([
+  parameters([
+    string(defaultValue: '', description: 'New Nexus Repository Manager Version', name: 'nexus_repository_manager_version'),
+    string(defaultValue: '', description: 'New Nexus Repository Manager Version Sha256', name: 'nexus_repository_manager_version_sha'),
+    string(defaultValue: '', description: 'New Nexus Repository Manager URL', name: 'nexus_repository_manager_url'),
+    booleanParam(defaultValue: false, description: 'Optional scan for policy violations', name: 'scan_for_policy_violations'),
+    booleanParam(defaultValue: false, description: 'Skip Pushing of Docker Image and Tags', name: 'skip_push'),
+  ])
+])
+
+node('ubuntu-zion') {
+  def commitId, commitDate, version, imageId, branch, dockerFileLocations
+  def organization = 'sonatype',
+      gitHubRepository = 'docker-nexus3',
+      credentialsId = 'integrations-github-api',
+      imageName = 'sonatype/nexus3',
+      archiveName = 'docker-nexus3',
+      dockerHubRepository = 'nexus3'
+  GitHub gitHub
+
+  try {
+    stage('Preparation') {
+      deleteDir()
+      OsTools.runSafe(this, "docker system prune -a -f")
+
+      def checkoutDetails = checkout scm
+
+      dockerFileLocations = [
+        "${pwd()}/Dockerfile.release.candidate"
+      ]
+
+      branch = checkoutDetails.GIT_BRANCH == 'origin/main' ? 'main' : checkoutDetails.GIT_BRANCH
+      commitId = checkoutDetails.GIT_COMMIT
+      commitDate = OsTools.runSafe(this, "git show -s --format=%cd --date=format:%Y%m%d-%H%M%S ${commitId}")
+
+      OsTools.runSafe(this, 'git config --global user.email sonatype-ci@sonatype.com')
+      OsTools.runSafe(this, 'git config --global user.name Sonatype CI')
+
+      version = readVersion()
+
+      def apiToken
+      withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: credentialsId,
+                        usernameVariable: 'GITHUB_API_USERNAME', passwordVariable: 'GITHUB_API_PASSWORD']]) {
+        apiToken = env.GITHUB_API_PASSWORD
+      }
+      gitHub = new GitHub(this, "${organization}/${gitHubRepository}", apiToken)
+
+      if (params.nexus_repository_manager_version && params.nexus_repository_manager_version_sha) {
+        stage('Update Repository Manager Version') {
+          OsTools.runSafe(this, "git checkout ${branch}")
+          dockerFileLocations.each { updateRepositoryManagerVersion(it) }
+          version = getShortVersion(params.nexus_repository_manager_version)
+        }
+      }
+    }
+    stage('Build') {
+      gitHub.statusUpdate commitId, 'pending', 'build', 'Build is running'
+
+      def hash = OsTools.runSafe(this, "docker build --quiet --no-cache --tag ${imageName} .")
+      imageId = hash.split(':')[1]
+
+      if (currentBuild.result == 'FAILURE') {
+        gitHub.statusUpdate commitId, 'failure', 'build', 'Build failed'
+        return
+      } else {
+        gitHub.statusUpdate commitId, 'success', 'build', 'Build succeeded'
+      }
+    }
+    stage('Test') {
+      gitHub.statusUpdate commitId, 'pending', 'test', 'Tests are running'
+
+      validateExpectations([
+        new Expectation('Has user nexus in group nexus present',
+            'id', '-ng nexus', 'nexus'),
+        new Expectation('Has nexus user java process present',
+            'ps', '-e -o command,user | grep -q ^/usr/lib/jvm/java.*nexus$ | echo $?', '0')
+      ])
+
+      if (currentBuild.result == 'FAILURE') {
+        gitHub.statusUpdate commitId, 'failure', 'test', 'Tests failed'
+        return
+      } else {
+        gitHub.statusUpdate commitId, 'success', 'test', 'Tests succeeded'
+      }
+    }
+
+    if (params.scan_for_policy_violations) {
+      stage('Evaluate Policies') {
+        runEvaluation({ stage ->
+          nexusPolicyEvaluation(
+            iqStage: stage,
+            iqApplication: 'docker-nexus3',
+            iqScanPatterns: [[scanPattern: "container:${imageName}"]],
+            failBuildOnNetworkError: true,
+          )}, 'release')
+      }
+    }
+
+    if (currentBuild.result == 'FAILURE') {
+      return
+    }
+    if (params.nexus_repository_manager_version && params.nexus_repository_manager_version_sha) {
+      stage('Commit Automated Code Update') {
+      }
+    }
+    stage('Archive') {
+      dir('build/target') {
+        OsTools.runSafe(this, "docker save ${imageName} | gzip > ${archiveName}.tar.gz")
+        archiveArtifacts artifacts: "${archiveName}.tar.gz", onlyIfSuccessful: true
+      }
+    }
+    if (!params.skip_push) {
+      input 'Push image and tags?'
+      stage('Push image') {
+
+          // push to internal repos
+          withSonatypeDockerRegistry() {
+            sh "docker tag ${imageId} docker-all.repo.sonatype.com/sonatype-internal/${dockerHubRepository}:${version}"
+            sh "docker push docker-all.repo.sonatype.com/sonatype-internal/${dockerHubRepository}:${version}"
+          }
+      }
+      stage('Push tags') {
+      }
+    }
+  } finally {
+    OsTools.runSafe(this, "docker logout")
+    OsTools.runSafe(this, "docker system prune -a -f")
+    OsTools.runSafe(this, 'git clean -f && git reset --hard origin/main')
+  }
+}
+
+def readVersion() {
+  def content = readFile 'Dockerfile'
+  for (line in content.split('\n')) {
+    if (line.startsWith('ARG NEXUS_VERSION=')) {
+      return getShortVersion(line.substring(18))
+    }
+  }
+  error 'Could not determine version.'
+}
+
+def getShortVersion(version) {
+  return version.split('-')[0]
+}
+
+def updateRepositoryManagerVersion(dockerFileLocation) {
+  def dockerFile = readFile(file: dockerFileLocation)
+
+  def metaVersionRegex = /(version=")(\d\.\d{1,3}\.\d\-\d{2})(" \\)/
+  def metaShortVersionRegex = /(release=")(\d\.\d{1,3}\.\d)(" \\)/
+
+  def versionRegex = /(ARG NEXUS_VERSION=)(\d\.\d{1,3}\.\d\-\d{2})/
+  def shaRegex = /(ARG NEXUS_DOWNLOAD_SHA256_HASH=)([A-Fa-f0-9]{64})/
+
+  def nexusUrlRegex = /(ARG NEXUS_DOWNLOAD_URL=)(.*$)/
+
+  dockerFile = dockerFile.replaceAll(metaVersionRegex, "\$1${params.nexus_repository_manager_version}\$3")
+  dockerFile = dockerFile.replaceAll(metaShortVersionRegex,
+    "\$1${params.nexus_repository_manager_version.substring(0, params.nexus_repository_manager_version.indexOf('-'))}\$3")
+  dockerFile = dockerFile.replaceAll(versionRegex, "\$1${params.nexus_repository_manager_version}")
+  dockerFile = dockerFile.replaceAll(shaRegex, "\$1${params.nexus_repository_manager_version_sha}")
+  dockerFile = dockerFile.replaceAll(nexusUrlRegex, "\$1${params.nexus_repository_manager_url}")
+
+  writeFile(file: dockerFileLocation, text: dockerFile)
+
+  dockerFile = readFile(file: dockerFileLocation)
+  echo dockerFile
+}
+


### PR DESCRIPTION
Before the official Nexus release, PMs want to test the release candidate by using the Nexus docker image.
This CI job allows you to publish the Nexus docker image to the repo.sonatype.com and then you can pull it by
```
docker pull docker-all.repo.sonatype.com/sonatype-internal/nexus3:3.XX.Y
```