### PR TITLE
NEXUS-42724 - add base image reference to images produced by the RedHat job

### DIFF
--- a/Jenkinsfile.rh
+++ b/Jenkinsfile.rh
@@ -32,15 +32,15 @@ node('ubuntu-zion') {
       '''
     }
     stage('Build') {
-      //withCredentials([
-      //  usernamePassword(
-      //      credentialsId: 'red-hat-quay-nexus-repository-manager',
-      //      usernameVariable: 'REGISTRY_LOGIN',
-      //      passwordVariable: 'REGISTRY_PASSWORD'),
-      //  string(
-      //      credentialsId: 'red-hat-api-token',
-      //      variable: 'API_TOKEN')
-      //]) {
+      withCredentials([
+        usernamePassword(
+            credentialsId: 'red-hat-quay-nexus-repository-manager',
+            usernameVariable: 'REGISTRY_LOGIN',
+            passwordVariable: 'REGISTRY_PASSWORD'),
+        string(
+            credentialsId: 'red-hat-api-token',
+            variable: 'API_TOKEN')
+      ]) {
         def dockerfilePath = 'Dockerfile.rh.ubi'
         if (params.java_version == OPENJDK11) {
           dockerfilePath = 'Dockerfile.rh.ubi.java11'
@@ -55,7 +55,7 @@ node('ubuntu-zion') {
         } else {
           sh "PATH=\$PATH:. VERSION='${version}' DOCKERFILE='${dockerfilePath}' BASE_IMG_REF='${baseImageReferenceStr}' ./build_red_hat_image.sh"
         }
-      //}
+      }
     }
   } finally {
     sh 'docker logout'

--- a/Jenkinsfile.rh
+++ b/Jenkinsfile.rh
@@ -32,15 +32,15 @@ node('ubuntu-zion') {
       '''
     }
     stage('Build') {
-      withCredentials([
-        usernamePassword(
-            credentialsId: 'red-hat-quay-nexus-repository-manager',
-            usernameVariable: 'REGISTRY_LOGIN',
-            passwordVariable: 'REGISTRY_PASSWORD'),
-        string(
-            credentialsId: 'red-hat-api-token',
-            variable: 'API_TOKEN')
-      ]) {
+      //withCredentials([
+      //  usernamePassword(
+      //      credentialsId: 'red-hat-quay-nexus-repository-manager',
+      //      usernameVariable: 'REGISTRY_LOGIN',
+      //      passwordVariable: 'REGISTRY_PASSWORD'),
+      //  string(
+      //      credentialsId: 'red-hat-api-token',
+      //      variable: 'API_TOKEN')
+      //]) {
         def dockerfilePath = 'Dockerfile.rh.ubi'
         if (params.java_version == OPENJDK11) {
           dockerfilePath = 'Dockerfile.rh.ubi.java11'
@@ -51,11 +51,11 @@ node('ubuntu-zion') {
         def baseImageReference = baseImageRefFactory.build(this, baseImage as String)
         def baseImageReferenceStr = baseImageReference.getReference()
         if (params.java_version == OPENJDK11) {
-          sh "PATH='\$PATH:.' VERSION=${version} DOCKERFILE=${dockerfilePath} BASE_IMG_REF=${baseImageReferenceStr} ./build_red_hat_image_for_java11.sh"
+          sh "PATH=\$PATH:. VERSION='${version}' DOCKERFILE='${dockerfilePath}' BASE_IMG_REF='${baseImageReferenceStr}' ./build_red_hat_image_for_java11.sh"
         } else {
-          sh "PATH='\$PATH:.' VERSION=${version} DOCKERFILE=${dockerfilePath} BASE_IMG_REF=${baseImageReferenceStr} ./build_red_hat_image.sh"
+          sh "PATH=\$PATH:. VERSION='${version}' DOCKERFILE='${dockerfilePath}' BASE_IMG_REF='${baseImageReferenceStr}' ./build_red_hat_image.sh"
         }
-      }
+      //}
     }
   } finally {
     sh 'docker logout'

--- a/Jenkinsfile.rh
+++ b/Jenkinsfile.rh
@@ -41,10 +41,19 @@ node('ubuntu-zion') {
             credentialsId: 'red-hat-api-token',
             variable: 'API_TOKEN')
       ]) {
+        def dockerfilePath = 'Dockerfile.rh.ubi'
         if (params.java_version == OPENJDK11) {
-          sh 'PATH="$PATH:." VERSION=$version ./build_red_hat_image_for_java11.sh'
+          dockerfilePath = 'Dockerfile.rh.ubi.java11'
+        }
+
+        def baseImage = extractBaseImage(dockerfilePath)
+        def baseImageRefFactory = load 'scripts/BaseImageReference.groovy'
+        def baseImageReference = baseImageRefFactory.build(this, baseImage as String)
+        def baseImageReferenceStr = baseImageReference.getReference()
+        if (params.java_version == OPENJDK11) {
+          sh "PATH='\$PATH:.' VERSION=${version} DOCKERFILE=${dockerfilePath} BASE_IMG_REF=${baseImageReferenceStr} ./build_red_hat_image_for_java11.sh"
         } else {
-          sh 'PATH="$PATH:." VERSION=$version ./build_red_hat_image.sh'
+          sh "PATH='\$PATH:.' VERSION=${version} DOCKERFILE=${dockerfilePath} BASE_IMG_REF=${baseImageReferenceStr} ./build_red_hat_image.sh"
         }
       }
     }
@@ -53,4 +62,12 @@ node('ubuntu-zion') {
     sh 'docker system prune -a -f'
     sh 'git clean -f && git reset --hard origin/main'
   }
+}
+
+def extractBaseImage (dockerFileLocation) {
+  def dockerFile = readFile(file: dockerFileLocation)
+  def baseImageRegex = "FROM\\s+([^\\s]+)"
+  def usedImages = dockerFile =~ baseImageRegex
+
+  return usedImages[0][1]
 }

--- a/build_red_hat_image.sh
+++ b/build_red_hat_image.sh
@@ -28,8 +28,6 @@
 set -x # log commands as they execute
 set -e # stop execution on the first failed command
 
-DOCKERFILE=Dockerfile.rh.ubi
-
 # from config/scanning page at red hat
 CERT_PROJECT_ID=5e61d90a38776799eb517bd2
 
@@ -39,7 +37,7 @@ IMAGE_LATEST="${REPOSITORY}/redhat-isv-containers/${CERT_PROJECT_ID}:latest"
 
 AUTHFILE="${HOME}/.docker/config.json"
 
-docker build -f "${DOCKERFILE}" -t "${IMAGE_TAG}" .
+docker build -f "${DOCKERFILE}" --label base-image-ref=${BASE_IMG_REF} -t "${IMAGE_TAG}" .
 docker tag "${IMAGE_TAG}" "${IMAGE_LATEST}"
 
 docker login "${REPOSITORY}" \

--- a/build_red_hat_image.sh
+++ b/build_red_hat_image.sh
@@ -20,6 +20,8 @@
 #   * https://github.com/redhat-openshift-ecosystem/openshift-preflight
 #   * https://podman.io/
 # * environment variables:
+#   * DOCKERFILE to be built
+#   * BASE_IMG_REF to add as a label to the image
 #   * VERSION of the docker image  to build for the red hat registry
 #   * REGISTRY_LOGIN from Red Hat config page for image
 #   * REGISTRY_PASSWORD from Red Hat config page for image
@@ -40,23 +42,16 @@ AUTHFILE="${HOME}/.docker/config.json"
 docker build -f "${DOCKERFILE}" --label base-image-ref=${BASE_IMG_REF} -t "${IMAGE_TAG}" .
 docker tag "${IMAGE_TAG}" "${IMAGE_LATEST}"
 
-echo "##### CHECK HERE IF THE PRODUCED IMAGE CONTAINS A VALID VALUE OF base-image-ref IN LABELS ######"
-sleep 5
+docker login "${REPOSITORY}" \
+       -u "${REGISTRY_LOGIN}" \
+       --password "${REGISTRY_PASSWORD}"
 
-docker inspect ${IMAGE_LATEST}
+docker push "${IMAGE_TAG}"
+docker push "${IMAGE_LATEST}"
 
-#docker login "${REPOSITORY}" \
-#       -u "${REGISTRY_LOGIN}" \
-#       --password "${REGISTRY_PASSWORD}"
-#
-#docker push "${IMAGE_TAG}"
-#docker push "${IMAGE_LATEST}"
-#
-#preflight check container \
-#          "${IMAGE_TAG}" \
-#          --docker-config="${AUTHFILE}" \
-#          --submit \
-#          --certification-project-id="${CERT_PROJECT_ID}" \
-#          --pyxis-api-token="${API_TOKEN}"
-
-echo "FINISHING"
+preflight check container \
+          "${IMAGE_TAG}" \
+          --docker-config="${AUTHFILE}" \
+          --submit \
+          --certification-project-id="${CERT_PROJECT_ID}" \
+          --pyxis-api-token="${API_TOKEN}"

--- a/build_red_hat_image.sh
+++ b/build_red_hat_image.sh
@@ -40,10 +40,9 @@ AUTHFILE="${HOME}/.docker/config.json"
 docker build -f "${DOCKERFILE}" --label base-image-ref=${BASE_IMG_REF} -t "${IMAGE_TAG}" .
 docker tag "${IMAGE_TAG}" "${IMAGE_LATEST}"
 
-echo "SLEEPING BEFORE PROCEEDING WITH THE TEST"
+echo "##### CHECK HERE IF THE PRODUCED IMAGE CONTAINS A VALID VALUE OF base-image-ref IN LABELS ######"
 sleep 5
 
-docker inspect ${IMAGE_TAG}
 docker inspect ${IMAGE_LATEST}
 
 #docker login "${REPOSITORY}" \

--- a/build_red_hat_image.sh
+++ b/build_red_hat_image.sh
@@ -40,16 +40,24 @@ AUTHFILE="${HOME}/.docker/config.json"
 docker build -f "${DOCKERFILE}" --label base-image-ref=${BASE_IMG_REF} -t "${IMAGE_TAG}" .
 docker tag "${IMAGE_TAG}" "${IMAGE_LATEST}"
 
-docker login "${REPOSITORY}" \
-       -u "${REGISTRY_LOGIN}" \
-       --password "${REGISTRY_PASSWORD}"
+echo "SLEEPING BEFORE PROCEEDING WITH THE TEST"
+sleep 5
 
-docker push "${IMAGE_TAG}"
-docker push "${IMAGE_LATEST}"
+docker inspect ${IMAGE_TAG}
+docker inspect ${IMAGE_LATEST}
 
-preflight check container \
-          "${IMAGE_TAG}" \
-          --docker-config="${AUTHFILE}" \
-          --submit \
-          --certification-project-id="${CERT_PROJECT_ID}" \
-          --pyxis-api-token="${API_TOKEN}"
+#docker login "${REPOSITORY}" \
+#       -u "${REGISTRY_LOGIN}" \
+#       --password "${REGISTRY_PASSWORD}"
+#
+#docker push "${IMAGE_TAG}"
+#docker push "${IMAGE_LATEST}"
+#
+#preflight check container \
+#          "${IMAGE_TAG}" \
+#          --docker-config="${AUTHFILE}" \
+#          --submit \
+#          --certification-project-id="${CERT_PROJECT_ID}" \
+#          --pyxis-api-token="${API_TOKEN}"
+
+echo "FINISHING"

--- a/build_red_hat_image_for_java11.sh
+++ b/build_red_hat_image_for_java11.sh
@@ -39,13 +39,12 @@ IMAGE_TAG="${REPOSITORY}/redhat-isv-containers/${CERT_PROJECT_ID}:${VERSION}-${J
 AUTHFILE="${HOME}/.docker/config.json"
 
 docker build -f "${DOCKERFILE}" --label base-image-ref=${BASE_IMG_REF} -t "${IMAGE_TAG}" .
-docker tag "${IMAGE_TAG}"
+docker tag "${IMAGE_TAG}" "${IMAGE_TAG}"
 
-echo "SLEEPING BEFORE PROCEEDING WITH THE TEST"
+echo "##### CHECK HERE IF THE PRODUCED IMAGE CONTAINS A VALID VALUE OF base-image-ref IN LABELS ######"
 sleep 5
 
 docker inspect ${IMAGE_TAG}
-docker inspect ${IMAGE_LATEST}
 
 #docker login "${REPOSITORY}" \
 #       -u "${REGISTRY_LOGIN}" \

--- a/build_red_hat_image_for_java11.sh
+++ b/build_red_hat_image_for_java11.sh
@@ -20,6 +20,8 @@
 #   * https://github.com/redhat-openshift-ecosystem/openshift-preflight
 #   * https://podman.io/
 # * environment variables:
+#   * DOCKERFILE to be built
+#   * BASE_IMG_REF to add as a label to the image
 #   * VERSION of the docker image  to build for the red hat registry
 #   * REGISTRY_LOGIN from Red Hat config page for image
 #   * REGISTRY_PASSWORD from Red Hat config page for image
@@ -41,22 +43,15 @@ AUTHFILE="${HOME}/.docker/config.json"
 docker build -f "${DOCKERFILE}" --label base-image-ref=${BASE_IMG_REF} -t "${IMAGE_TAG}" .
 docker tag "${IMAGE_TAG}" "${IMAGE_TAG}"
 
-echo "##### CHECK HERE IF THE PRODUCED IMAGE CONTAINS A VALID VALUE OF base-image-ref IN LABELS ######"
-sleep 5
+docker login "${REPOSITORY}" \
+       -u "${REGISTRY_LOGIN}" \
+       --password "${REGISTRY_PASSWORD}"
 
-docker inspect ${IMAGE_TAG}
+docker push "${IMAGE_TAG}"
 
-#docker login "${REPOSITORY}" \
-#       -u "${REGISTRY_LOGIN}" \
-#       --password "${REGISTRY_PASSWORD}"
-#
-#docker push "${IMAGE_TAG}"
-#
-#preflight check container \
-#          "${IMAGE_TAG}" \
-#          --docker-config="${AUTHFILE}" \
-#          --submit \
-#          --certification-project-id="${CERT_PROJECT_ID}" \
-#          --pyxis-api-token="${API_TOKEN}"
-
-echo "FINISHING"
+preflight check container \
+          "${IMAGE_TAG}" \
+          --docker-config="${AUTHFILE}" \
+          --submit \
+          --certification-project-id="${CERT_PROJECT_ID}" \
+          --pyxis-api-token="${API_TOKEN}"

--- a/build_red_hat_image_for_java11.sh
+++ b/build_red_hat_image_for_java11.sh
@@ -41,15 +41,23 @@ AUTHFILE="${HOME}/.docker/config.json"
 docker build -f "${DOCKERFILE}" --label base-image-ref=${BASE_IMG_REF} -t "${IMAGE_TAG}" .
 docker tag "${IMAGE_TAG}"
 
-docker login "${REPOSITORY}" \
-       -u "${REGISTRY_LOGIN}" \
-       --password "${REGISTRY_PASSWORD}"
+echo "SLEEPING BEFORE PROCEEDING WITH THE TEST"
+sleep 5
 
-docker push "${IMAGE_TAG}"
+docker inspect ${IMAGE_TAG}
+docker inspect ${IMAGE_LATEST}
 
-preflight check container \
-          "${IMAGE_TAG}" \
-          --docker-config="${AUTHFILE}" \
-          --submit \
-          --certification-project-id="${CERT_PROJECT_ID}" \
-          --pyxis-api-token="${API_TOKEN}"
+#docker login "${REPOSITORY}" \
+#       -u "${REGISTRY_LOGIN}" \
+#       --password "${REGISTRY_PASSWORD}"
+#
+#docker push "${IMAGE_TAG}"
+#
+#preflight check container \
+#          "${IMAGE_TAG}" \
+#          --docker-config="${AUTHFILE}" \
+#          --submit \
+#          --certification-project-id="${CERT_PROJECT_ID}" \
+#          --pyxis-api-token="${API_TOKEN}"
+
+echo "FINISHING"

--- a/build_red_hat_image_for_java11.sh
+++ b/build_red_hat_image_for_java11.sh
@@ -28,7 +28,6 @@
 set -x # log commands as they execute
 set -e # stop execution on the first failed command
 
-DOCKERFILE=Dockerfile.rh.ubi.java11
 JAVA_VERSION="java11"
 
 # from config/scanning page at red hat
@@ -39,7 +38,7 @@ IMAGE_TAG="${REPOSITORY}/redhat-isv-containers/${CERT_PROJECT_ID}:${VERSION}-${J
 
 AUTHFILE="${HOME}/.docker/config.json"
 
-docker build -f "${DOCKERFILE}" -t "${IMAGE_TAG}" .
+docker build -f "${DOCKERFILE}" --label base-image-ref=${BASE_IMG_REF} -t "${IMAGE_TAG}" .
 docker tag "${IMAGE_TAG}"
 
 docker login "${REPOSITORY}" \


### PR DESCRIPTION
This PR introduces a new label inside the Docker Image published on the RedHat catalog. It is a continuation of a [previous PR](https://github.com/sonatype/docker-nexus3/pull/180) that is already merged that introduced the same changes for internal images and images published in Docker Hub.


This pull request makes the following changes:
* It changes the Jenkins job used to publish Nexus images to the RedHat Catalog in order to add the logic for obtaining the base image reference link.
* It changes the scripts associated to such job to include the base image reference link as a label called `base-image-ref`

**Testing**

To be able to test these changes without publishing anything [another branch](https://github.com/sonatype/docker-nexus3/tree/NEXUS-42440-add-base-image-reference-redhat-jobs-TEST) is created, it includes the same code as this branch with the publishing lines commented.

It relates to the following issue:
* JIRA: https://sonatype.atlassian.net/browse/NEXUS-42724
