### PR TITLE
Revert "NEXUS-42789 - Remove quiet flag from buidls (#187)"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ node('ubuntu-zion') {
     stage('Build') {
       gitHub.statusUpdate commitId, 'pending', 'build', 'Build is running'
 
-      def hash = OsTools.runSafe(this, "docker build --no-cache --tag ${imageName} .")
+      def hash = OsTools.runSafe(this, "docker build --quiet --no-cache --tag ${imageName} .")
       imageId = hash.split(':')[1]
 
       if (currentBuild.result == 'FAILURE') {

--- a/Jenkinsfile-Internal-Release
+++ b/Jenkinsfile-Internal-Release
@@ -75,7 +75,7 @@ node('ubuntu-zion') {
       def baseImageRefFactory = load 'scripts/BaseImageReference.groovy'
       def baseImageReference = baseImageRefFactory.build(this, baseImage as String)
       def baseImageReferenceStr = baseImageReference.getReference()
-      def hash = OsTools.runSafe(this, "docker build --label base-image-ref='${baseImageReferenceStr}' --no-cache --tag ${imageName} . -f ${dockerfilePath}")
+      def hash = OsTools.runSafe(this, "docker build --quiet --label base-image-ref='${baseImageReferenceStr}' --no-cache --tag ${imageName} . -f ${dockerfilePath}")
       imageId = hash.split(':')[1]
     }
     if (params.scan_for_policy_violations) {

--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -113,7 +113,7 @@ node('ubuntu-zion') {
       def baseImageRefFactory = load 'scripts/BaseImageReference.groovy'
       def baseImageReference = baseImageRefFactory.build(this, baseImage as String)
       def baseImageReferenceStr = baseImageReference.getReference()
-      def hash = OsTools.runSafe(this, "docker build --label base-image-ref='${baseImageReferenceStr}' --no-cache --tag ${imageName} . -f ${dockerfilePath}")
+      def hash = OsTools.runSafe(this, "docker build --quiet --label base-image-ref='${baseImageReferenceStr}' --no-cache --tag ${imageName} . -f ${dockerfilePath}")
       imageId = hash.split(':')[1]
 
       if (currentBuild.result == 'FAILURE') {


### PR DESCRIPTION
It appears that when running the jobs that removing the quiet flag leads to Jenkins being unable to identify the hash. Temporarily reverting the change until we can identify an alternative.