### PR TITLE
NEXUS-43508

### DIFF
--- a/Dockerfile.alpine.java11
+++ b/Dockerfile.alpine.java11
@@ -55,6 +55,9 @@ RUN apk add openjdk11 tar procps gzip curl shadow \
     && groupadd --gid 200 -r nexus \
     && useradd --uid 200 -r nexus -g nexus -s /bin/false -d /opt/sonatype/nexus -c 'Nexus Repository Manager user'
 
+RUN apk del --no-cache openssl || true
+RUN apk update && apk add --no-cache openssl
+
 WORKDIR ${SONATYPE_DIR}
 
 # Download nexus & setup directories

--- a/Dockerfile.alpine.java17
+++ b/Dockerfile.alpine.java17
@@ -55,6 +55,9 @@ RUN apk add openjdk17 tar procps gzip curl shadow \
     && groupadd --gid 200 -r nexus \
     && useradd --uid 200 -r nexus -g nexus -s /bin/false -d /opt/sonatype/nexus -c 'Nexus Repository Manager user'
 
+RUN apk del --no-cache openssl || true
+RUN apk update && apk add --no-cache openssl
+
 WORKDIR ${SONATYPE_DIR}
 
 # Download nexus & setup directories


### PR DESCRIPTION
Bump openssl to a non vulnerable version.

[NEXUS-43508](https://sonatype.atlassian.net/browse/NEXUS-43508)

[NEXUS-43508]: https://sonatype.atlassian.net/browse/NEXUS-43508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ