### PR TITLE
build: skip the prompt

### DIFF
--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -138,7 +138,6 @@ node('ubuntu-zion') {
       }
     }
     if (branch == 'main' && !params.skip_push && !params.update_latest_only) {
-      input 'Push image and tags?'
       stage('Push image') {
         def dockerhubApiToken
 


### PR DESCRIPTION
This removes the input prompt to "Proceed" or "Abort" with the pipeline job.

