### PR TITLE
updating openshift-preflight version on Jenkinsfile.rh

### DIFF
--- a/Jenkinsfile.rh
+++ b/Jenkinsfile.rh
@@ -19,7 +19,7 @@ node('ubuntu-zion') {
       sh 'docker system prune -a -f'
       sh '''
         wget -q -O preflight \
-          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.9.4/preflight-linux-amd64
+          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.10.0/preflight-linux-amd64
         chmod 755 preflight
       '''
     }


### PR DESCRIPTION
### Changes description
(🧹 Chore)
updating openshift-preflight version on Jenkinsfile.rh

### Context
Openshift-preflight version needs to be upgraded for RedHat OpenShift Operator release NXRM 3.72.0

### JIRA ticket
https://sonatype.atlassian.net/browse/NEXUS-43864