### PR TITLE
update openshift-preflight to 1.10.2

### DIFF
--- a/Jenkinsfile.rh
+++ b/Jenkinsfile.rh
@@ -19,7 +19,7 @@ node('ubuntu-zion') {
       sh 'docker system prune -a -f'
       sh '''
         wget -q -O preflight \
-          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.10.1/preflight-linux-amd64
+          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.10.2/preflight-linux-amd64
         chmod 755 preflight
       '''
     }

--- a/Jenkinsfile.rh
+++ b/Jenkinsfile.rh
@@ -19,7 +19,7 @@ node('ubuntu-zion') {
       sh 'docker system prune -a -f'
       sh '''
         wget -q -O preflight \
-          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.10.0/preflight-linux-amd64
+          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.10.1/preflight-linux-amd64
         chmod 755 preflight
       '''
     }


### PR DESCRIPTION
Fixes the jenkins job https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/Red%20Hat/job/docker-nexus-repository-red-hat-release/45/console

```
2024-11-05 07:59:06 GMT  time="2024-11-05T07:59:05Z" level=info msg="preparing results that will be submitted to Red Hat"
2024-11-05 07:59:06 GMT  time="2024-11-05T07:59:06Z" level=error msg=release-url error="invalid preflight version, please download the latest version and re-submit"
2024-11-05 07:59:06 GMT  Error: could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.10.0' is not supported. Supported versions are: ['1.10.1', '1.10.2']", "status": 400, "trace_id": "0xe402cc459ab620221b025d6e54607b83"}
2024-11-05 07:59:06 GMT  2024/11/05 07:59:06 could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.10.0' is not supported. Supported versions are: ['1.10.1', '1.10.2']", "status": 400, "trace_id": "0xe402cc459ab620221b025d6e54607b83"}
```
