### PR TITLE
NEXUS-44919: update to UBI 9 (minimal)

### DIFF
--- a/Dockerfile.java17
+++ b/Dockerfile.java17
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/redhat/ubi9-minimal
 
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \

--- a/Dockerfile.java17
+++ b/Dockerfile.java17
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/redhat/ubi9-minimal
+FROM redhat/ubi9-minimal
 
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \

--- a/Dockerfile.rh.ubi.java17
+++ b/Dockerfile.rh.ubi.java17
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/redhat/ubi9-minimal
 
 LABEL name="Nexus Repository Manager" \
       vendor=Sonatype \

--- a/Dockerfile.rh.ubi.java17
+++ b/Dockerfile.rh.ubi.java17
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/redhat/ubi9-minimal
+FROM redhat/ubi9-minimal
 
 LABEL name="Nexus Repository Manager" \
       vendor=Sonatype \


### PR DESCRIPTION
Exporting the internal changes so that the 3.76.0 release images based off of UBI are upgraded to UBI 9.