### PR TITLE
NEXUS-46321: add policy evaluation step

### DIFF
--- a/Jenkinsfile-sbom-release
+++ b/Jenkinsfile-sbom-release
@@ -163,6 +163,17 @@ dockerizedRunPipeline(
         env['nexusVersion'] = dockerInspectLabel(DOCKER_NEXUS_IMAGE_NAME, params.docker_nexus3_tag, "version")
         env['dockerImageVersion'] = dockerInspectLabel(DOCKER_NEXUS_IMAGE_NAME, params.docker_nexus3_tag, "release")
         env['ubiImageId'] = baseImageRef.contains("image=") ? baseImageRef.split("image=")[1] : ""
+
+        runEvaluation({ stage ->
+          def iqApplicationName = getNexusReportName(params.docker_nexus3_tag)
+
+          nexusPolicyEvaluation(
+            iqStage: stage,
+            iqApplication: iqApplicationName,
+            iqScanPatterns: [[scanPattern: "container:${DOCKER_NEXUS_IMAGE_NAME}:${params.docker_nexus3_tag}"]],
+            failBuildOnNetworkError: true,
+          )
+        }, 'release')
       }
     },
     run: {


### PR DESCRIPTION
In NEXUS-46138 we needed to significantly refactor the publishing job. That job previously carried an IQ policy evaluation that no longer fits in how that job needs to work to achieve its goals. Restoring the policy evaluation step in the prepare phase will ensure its present for the later SBOM collection.

