### PR TITLE
Fix short-name resolution of java17 image

### DIFF
--- a/Dockerfile.java17
+++ b/Dockerfile.java17
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM redhat/ubi9-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \

--- a/Dockerfile.rh.ubi.java17
+++ b/Dockerfile.rh.ubi.java17
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM redhat/ubi9-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 LABEL name="Nexus Repository Manager" \
       vendor=Sonatype \


### PR DESCRIPTION
When the `redhat/ubi9-minimal` image is used in a pipeline, users receive the following error:
```
Error: creating build container: short-name resolution enforced but cannot prompt without a TTY
```

This pull request makes the following changes:
* This change uses the long form resolution of `registry.access.redhat.com/ubi9/ubi-minimal` for compatibility with pipelines

