### PR TITLE
fix policy violation for sbom deployer

### DIFF
--- a/build-images/Dockerfile.sbom-deployer
+++ b/build-images/Dockerfile.sbom-deployer
@@ -1,3 +1,3 @@
-FROM docker-all.repo.sonatype.com/python:3.12
+FROM docker-all.repo.sonatype.com/python:3.13-alpine
 
-RUN apt-get update && apt-get install -y jq curl
+RUN apk update && apk add --no-cache jq curl


### PR DESCRIPTION
Updates the base image to a no quarantined python image

https://jenkins.ci.sonatype.dev/job/nxrm/job/nxrm3/job/Docker%20image%20SBOM%20release/180/console
