### PR TITLE
update to 3.84.0-03 release (version and SHA)

### DIFF
--- a/Dockerfile.alpine.java17
+++ b/Dockerfile.alpine.java17
@@ -17,8 +17,8 @@ FROM alpine
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.83.2-01" \
-      release="3.83.2" \
+      version="3.84.0-03" \
+      release="3.84.0" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.83.2-01
+ARG NEXUS_VERSION=3.84.0-03
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=7aa80aefccd5adfbe2ff3fb23d3e0831c1ce34a32030b916564a035d78d3946e
+ARG NEXUS_DOWNLOAD_SHA256_HASH=3bf9a489b98cd686a5318c2e259fbc81d9e954f01c0e797e849ca0b9830a7c8e
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype

--- a/Dockerfile.java17
+++ b/Dockerfile.java17
@@ -17,8 +17,8 @@ FROM redhat/ubi9-minimal
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.83.2-01" \
-      release="3.83.2" \
+      version="3.84.0-03" \
+      release="3.84.0" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.83.2-01
+ARG NEXUS_VERSION=3.84.0-03
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=7aa80aefccd5adfbe2ff3fb23d3e0831c1ce34a32030b916564a035d78d3946e
+ARG NEXUS_DOWNLOAD_SHA256_HASH=3bf9a489b98cd686a5318c2e259fbc81d9e954f01c0e797e849ca0b9830a7c8e
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype

--- a/Dockerfile.rh.ubi.java17
+++ b/Dockerfile.rh.ubi.java17
@@ -17,8 +17,8 @@ FROM redhat/ubi9-minimal
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.83.1-03" \
-      release="3.83.1" \
+      version="3.84.0-03" \
+      release="3.84.0" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.83.1-03
+ARG NEXUS_VERSION=3.84.0-03
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=e0b6e8b29834dbe137697309c9bbe4e0445b9eb6286afddff6946e0f38d9bd73
+ARG NEXUS_DOWNLOAD_SHA256_HASH=3bf9a489b98cd686a5318c2e259fbc81d9e954f01c0e797e849ca0b9830a7c8e
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype


### PR DESCRIPTION
SHA256:
<img width="1816" height="460" alt="image" src="https://github.com/user-attachments/assets/dc04791a-a0f1-49e2-9506-07c0dff287c2" />



This pull request updates the Nexus Repository Manager version used in all Java 17 Dockerfiles to `3.84.0-03`. It also updates the associated release numbers and SHA256 hashes to ensure the correct version is downloaded and verified.

Version and release updates:

* Bumped the `version` and `release` labels to `3.84.0-03` and `3.84.0` in `Dockerfile.alpine.java17`, `Dockerfile.java17`, and `Dockerfile.rh.ubi.java17` to reflect the new Nexus Repository Manager release. [[1]](diffhunk://#diff-cf1dc8e323f51a3f7ce3460b17fa687da0fc05d13ec5e661b989068d1abf099aL20-R21) [[2]](diffhunk://#diff-358ec829e7404b409b618240e5568130e7d7685fcb3c8fdee225b4f4fd422654L20-R21) [[3]](diffhunk://#diff-706f40a986630452a9e1a1ab5471311a322bf9c91b2323e3a154af12f32551caL20-R21)
* Updated the `NEXUS_VERSION` build argument to `3.84.0-03` in all three Dockerfiles. [[1]](diffhunk://#diff-cf1dc8e323f51a3f7ce3460b17fa687da0fc05d13ec5e661b989068d1abf099aL39-R41) [[2]](diffhunk://#diff-358ec829e7404b409b618240e5568130e7d7685fcb3c8fdee225b4f4fd422654L39-R41) [[3]](diffhunk://#diff-706f40a986630452a9e1a1ab5471311a322bf9c91b2323e3a154af12f32551caL39-R41)

Security and integrity:

* Updated the `NEXUS_DOWNLOAD_SHA256_HASH` argument in all Dockerfiles to match the new release's hash, ensuring the downloaded artifact is verified. [[1]](diffhunk://#diff-cf1dc8e323f51a3f7ce3460b17fa687da0fc05d13ec5e661b989068d1abf099aL39-R41) [[2]](diffhunk://#diff-358ec829e7404b409b618240e5568130e7d7685fcb3c8fdee225b4f4fd422654L39-R41) [[3]](diffhunk://#diff-706f40a986630452a9e1a1ab5471311a322bf9c91b2323e3a154af12f32551caL39-R41)
