### PR TITLE
Upgrading preflight to 1.14.1 version.

### DIFF
--- a/Jenkinsfile.rh
+++ b/Jenkinsfile.rh
@@ -19,7 +19,7 @@ node('ubuntu-zion') {
       sh 'docker system prune -a -f'
       sh '''
         wget -q -O preflight \
-          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.13.0/preflight-linux-amd64
+          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.14.1/preflight-linux-amd64
         chmod 755 preflight
       '''
     }


### PR DESCRIPTION
This pull request updates the version of the `preflight` tool used in the Jenkins pipeline. The change ensures that the pipeline uses the latest release of `preflight`.

Dependency version update:

* Updated the download link in `Jenkinsfile.rh` to use `preflight` version 1.14.1 instead of 1.13.0.
