### PR TITLE
Use numeric uid instead of username in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN microdnf remove -y shadow-utils
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081
-USER nexus
+USER 200
 
 ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
 

--- a/Dockerfile.alpine.java11
+++ b/Dockerfile.alpine.java11
@@ -85,7 +85,7 @@ RUN apk del gzip shadow
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081
-USER nexus
+USER 200
 
 ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
 

--- a/Dockerfile.alpine.java17
+++ b/Dockerfile.alpine.java17
@@ -82,7 +82,7 @@ RUN apk del gzip shadow
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081
-USER nexus
+USER 200
 
 ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
 

--- a/Dockerfile.java11
+++ b/Dockerfile.java11
@@ -84,7 +84,7 @@ RUN microdnf remove -y shadow-utils
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081
-USER nexus
+USER 200
 
 ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
 

--- a/Dockerfile.java17
+++ b/Dockerfile.java17
@@ -84,7 +84,7 @@ RUN microdnf remove -y gzip shadow-utils
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081
-USER nexus
+USER 200
 
 ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs -Dfile.encoding=UTF-8"
 

--- a/Dockerfile.rh.ubi.java17
+++ b/Dockerfile.rh.ubi.java17
@@ -94,7 +94,7 @@ RUN microdnf remove -y gzip shadow-utils
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081
-USER nexus
+USER 200
 
 ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
 


### PR DESCRIPTION
Systems configured to disallow running images as root aren't able to run images that use a username string value for the `USER` because they can't validate that a username isn't mapped to uid 0 (root). To allow images to run on such systems, use the uid of the user as the value for `USER` instead of the username. 

This has no downside when running in environments that do not do non-root validation.

See `MustRunAsNonRoot` at https://kubernetes.io/docs/reference/access-authn-authz/psp-to-pod-security-standards/ and https://github.com/kubernetes/kubernetes/pull/56503