### PR TITLE
Nexus 51405 java25 upgrade

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,7 +14,7 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Determine Version
-              run: echo "NXRM_VERSION=$(grep release Dockerfile.java21 | cut -d "=" -f2 | tr -d '" \')" >> $GITHUB_ENV
+              run: echo "NXRM_VERSION=$(grep release Dockerfile.java25 | cut -d "=" -f2 | tr -d '" \')" >> $GITHUB_ENV
 
             - run: echo "Building NXRM ${{ env.NXRM_VERSION }} for ARM"
 
@@ -27,20 +27,20 @@ jobs:
                   username: ${{ secrets.REGISTRY_USERNAME }}
                   password: ${{ secrets.REGISTRY_TOKEN }}
 
-            - name: Build and push Java 21
+            - name: Build and push Java 25
               uses: docker/build-push-action@v5
               with:
                   context: .
-                  file: ./Dockerfile.java21
+                  file: ./Dockerfile.java25
                   platforms: linux/arm64,linux/amd64
                   push: true
                   tags: sonatypecommunity/nexus3:latest , sonatypecommunity/nexus3:${{ env.NXRM_VERSION }}
 
-            - name: Build and push Java 21 (alpine)
+            - name: Build and push Java 25 (alpine)
               uses: docker/build-push-action@v5
               with:
                   context: .
-                  file: ./Dockerfile.alpine.java21
+                  file: ./Dockerfile.alpine.java25
                   platforms: linux/arm64,linux/amd64
                   push: true
                   tags: sonatypecommunity/nexus3:${{ env.NXRM_VERSION }}-alpine

--- a/Dockerfile.alpine.java25
+++ b/Dockerfile.alpine.java25
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM redhat/ubi9-minimal
+FROM alpine
 
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
@@ -46,18 +46,16 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
     NEXUS_DATA=/nexus-data \
     NEXUS_CONTEXT='' \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \
-    DOCKER_TYPE='rh-docker'
+    DOCKER_TYPE='alpine'
 
-# Install Java, tar, and unzip
-RUN microdnf update -y \
-    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
-          java-21-openjdk-headless tar procps shadow-utils gzip unzip glibc-langpack-en \
-    && microdnf clean all \
+# Install Java & tar
+RUN apk add openjdk25 tar procps gzip curl shadow \
+    && apk cache clean \
     && groupadd --gid 200 -r nexus \
     && useradd --uid 200 -r nexus -g nexus -s /bin/false -d /opt/sonatype/nexus -c 'Nexus Repository Manager user'
 
-ENV LANG=en_US.UTF-8
-ENV LC_ALL=en_US.UTF-8
+RUN apk del --no-cache openssl || true
+RUN apk update && apk add --no-cache openssl
 
 WORKDIR ${SONATYPE_DIR}
 
@@ -79,18 +77,13 @@ RUN echo "#!/bin/bash" >> ${SONATYPE_DIR}/start-nexus-repository-manager.sh \
    && chmod a+x ${SONATYPE_DIR}/nexus/bin/nexus \
    && sed -e '/^nexus-context/ s:$:${NEXUS_CONTEXT}:' -i ${NEXUS_HOME}/etc/nexus-default.properties
 
-# Remove dependencies added for extracting Nexus
-# Remove CUPS, ignore the fact openjdk depends on it
-# Remove expat, nss-> crypto-policies-scripts -> python3 -> expat
-RUN microdnf remove -y gzip shadow-utils \
-   && rpm --erase --nodeps cups-libs \
-   && rpm --erase --nodeps expat
+RUN apk del gzip shadow
 
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081
 USER nexus
 
-ENV INSTALL4J_ADD_VM_PARAMS="-Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs -Dfile.encoding=UTF-8"
+ENV INSTALL4J_ADD_VM_PARAMS="-Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
 
 CMD ["/opt/sonatype/nexus/bin/nexus", "run"]

--- a/Dockerfile.java25
+++ b/Dockerfile.java25
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine
+FROM redhat/ubi9-minimal
 
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
@@ -46,16 +46,18 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
     NEXUS_DATA=/nexus-data \
     NEXUS_CONTEXT='' \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \
-    DOCKER_TYPE='alpine'
+    DOCKER_TYPE='rh-docker'
 
-# Install Java & tar
-RUN apk add openjdk21 tar procps gzip curl shadow \
-    && apk cache clean \
+# Install Java, tar, and unzip
+RUN microdnf update -y \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
+          java-25-openjdk-headless tar procps shadow-utils gzip unzip glibc-langpack-en \
+    && microdnf clean all \
     && groupadd --gid 200 -r nexus \
     && useradd --uid 200 -r nexus -g nexus -s /bin/false -d /opt/sonatype/nexus -c 'Nexus Repository Manager user'
 
-RUN apk del --no-cache openssl || true
-RUN apk update && apk add --no-cache openssl
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR ${SONATYPE_DIR}
 
@@ -77,13 +79,18 @@ RUN echo "#!/bin/bash" >> ${SONATYPE_DIR}/start-nexus-repository-manager.sh \
    && chmod a+x ${SONATYPE_DIR}/nexus/bin/nexus \
    && sed -e '/^nexus-context/ s:$:${NEXUS_CONTEXT}:' -i ${NEXUS_HOME}/etc/nexus-default.properties
 
-RUN apk del gzip shadow
+# Remove dependencies added for extracting Nexus
+# Remove CUPS, ignore the fact openjdk depends on it
+# Remove expat, nss-> crypto-policies-scripts -> python3 -> expat
+RUN microdnf remove -y gzip shadow-utils \
+   && rpm --erase --nodeps cups-libs \
+   && rpm --erase --nodeps expat
 
 VOLUME ${NEXUS_DATA}
 
 EXPOSE 8081
 USER nexus
 
-ENV INSTALL4J_ADD_VM_PARAMS="-Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs"
+ENV INSTALL4J_ADD_VM_PARAMS="-Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs -Dfile.encoding=UTF-8"
 
 CMD ["/opt/sonatype/nexus/bin/nexus", "run"]

--- a/Dockerfile.rh.ubi
+++ b/Dockerfile.rh.ubi
@@ -1,0 +1,1 @@
+Dockerfile.rh.ubi.java25

--- a/Dockerfile.rh.ubi
+++ b/Dockerfile.rh.ubi
@@ -1,1 +1,0 @@
-Dockerfile.rh.ubi.java25

--- a/Dockerfile.rh.ubi.java25
+++ b/Dockerfile.rh.ubi.java25
@@ -51,7 +51,7 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
 # Install Java, tar, and unzip
 RUN microdnf update -y \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
-          java-21-openjdk-headless tar procps shadow-utils gzip unzip glibc-langpack-en \
+          java-25-openjdk-headless tar procps shadow-utils gzip unzip glibc-langpack-en \
     && microdnf clean all \
     && groupadd --gid 200 -r nexus \
     && useradd --uid 200 -r nexus -g nexus -s /bin/false -d /opt/sonatype/nexus -c 'Nexus Repository Manager user'

--- a/Jenkinsfile-Internal-Release
+++ b/Jenkinsfile-Internal-Release
@@ -6,8 +6,8 @@
 @Library(['private-pipeline-library', 'jenkins-shared']) _
 import com.sonatype.jenkins.pipeline.OsTools
 
-String OPENJDK21 = 'OpenJDK 21'
-List<String> javaVersions = [OPENJDK21]
+String OPENJDK25 = 'OpenJDK 25'
+List<String> javaVersions = [OPENJDK25]
 
 properties([
     parameters([
@@ -23,12 +23,12 @@ node('ubuntu-zion') {
   def imageName = 'sonatype/nexus3',
       archiveName = 'docker-nexus3'
 
-  def JAVA_21 = 'java21'
-  def DOCKERFILE_JAVA_21 = 'Dockerfile.java21'
-  def DOCKERFILE_ALPINE_JAVA_21 = 'Dockerfile.alpine.java21'
+  def JAVA_25 = 'java25'
+  def DOCKERFILE_JAVA_25 = 'Dockerfile.java25'
+  def DOCKERFILE_ALPINE_JAVA_25 = 'Dockerfile.alpine.java25'
 
   def dockerfileMap = [
-    (OPENJDK21): [DOCKERFILE_JAVA_21, DOCKERFILE_ALPINE_JAVA_21]
+    (OPENJDK25): [DOCKERFILE_JAVA_25, DOCKERFILE_ALPINE_JAVA_25]
   ]
   try {
     stage('Preparation') {
@@ -49,15 +49,15 @@ node('ubuntu-zion') {
       if (params.nexus_repository_manager_version) {
         stage('Update Repository Manager Version') {
           OsTools.runSafe(this, "git checkout ${branch}")
-          dockerfileMap[OPENJDK21].each { dockerfile ->
-            updateRepositoryManagerVersion("${pwd()}/${dockerfile}", JAVA_21)
+          dockerfileMap[OPENJDK25].each { dockerfile ->
+            updateRepositoryManagerVersion("${pwd()}/${dockerfile}", JAVA_25)
             }
           version = getShortVersion(params.nexus_repository_manager_version)
         }
       }
     }
-    def dockerfilePath = dockerfileMap[OPENJDK21][0]
-    def alpineDockerfilePath = dockerfileMap[OPENJDK21][1]
+    def dockerfilePath = dockerfileMap[OPENJDK25][0]
+    def alpineDockerfilePath = dockerfileMap[OPENJDK25][1]
 
     stage('Build UBI Image') {
       def baseImage = extractBaseImage(dockerfilePath)
@@ -126,7 +126,7 @@ node('ubuntu-zion') {
 }
 
 def readVersion() {
-  def content = readFile 'Dockerfile.java21'
+  def content = readFile 'Dockerfile.java25'
   for (line in content.split('\n')) {
     if (line.startsWith('ARG NEXUS_VERSION=')) {
       return getShortVersion(line.substring(18))

--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -33,7 +33,7 @@ node('ubuntu-zion') {
     }
 
     stage('Build, Tag, and Push Images to dockerhub') {
-      def dockerfilePath = 'Dockerfile.java21'
+      def dockerfilePath = 'Dockerfile.java25'
       def baseImage = extractBaseImage(dockerfilePath)
       def baseImageRefFactory = load 'scripts/BaseImageReference.groovy'
       def baseImageReference = baseImageRefFactory.build(this, baseImage as String)
@@ -58,7 +58,7 @@ node('ubuntu-zion') {
         def hash = OsTools.runSafe(this, buildUbiImage)
 
         // Build Alpine Image
-        def alpineDockerfilePath = 'Dockerfile.alpine.java21'
+        def alpineDockerfilePath = 'Dockerfile.alpine.java25'
         def buildAlpineImage = """
         docker buildx build \
           --platform linux/amd64,linux/arm64 \

--- a/Jenkinsfile.rh
+++ b/Jenkinsfile.rh
@@ -33,7 +33,7 @@ node('ubuntu-zion') {
             credentialsId: 'red-hat-api-token',
             variable: 'API_TOKEN')
       ]) {
-        def dockerfilePath = 'Dockerfile.rh.ubi.java21'
+        def dockerfilePath = 'Dockerfile.rh.ubi.java25'
 
         def baseImage = extractBaseImage(dockerfilePath)
         def baseImageRefFactory = load 'scripts/BaseImageReference.groovy'

--- a/README.md
+++ b/README.md
@@ -116,23 +116,23 @@ In addition to the Universal Base Image, we can build images based on:
 
 **As of version 3.91.0, the Alpine-based image is the default for Sonatype Nexus Repository.**
 
-The Alpine-based container image can be created using [Dockerfile.alpine.java21](https://github.com/sonatype/docker-nexus3/blob/main/Dockerfile.alpine.java21). This Dockerfile is built to leverage the minimalistic and efficient nature of Alpine Linux, emphasizing fewer dependencies to achieve a cleaner SBOM (Software Bill of Materials) and a stronger security posture.
+The Alpine-based container image can be created using [Dockerfile.alpine.java25](https://github.com/sonatype/docker-nexus3/blob/main/Dockerfile.alpine.java25). This Dockerfile is built to leverage the minimalistic and efficient nature of Alpine Linux, emphasizing fewer dependencies to achieve a cleaner SBOM (Software Bill of Materials) and a stronger security posture.
 
 The Alpine-based container image includes minimal dependencies and uses an ENTRYPOINT script to ensure the application runs with the necessary permissions. It is optimized for rapid deployment and efficient resource usage.
 
 The Alpine-based container image is available from Docker Hub and can be pulled using the following tags:
 
-- `sonatype/nexus3:latest` - Latest Alpine-based release (runs Java 21)
-- `sonatype/nexus3:3.XX.y` - Specific version, Alpine-based (runs Java 21)
-- `sonatype/nexus3:3.XX.y-alpine` - Explicit Alpine tag (runs Java 21)
+- `sonatype/nexus3:latest` - Latest Alpine-based release (runs Java 25)
+- `sonatype/nexus3:3.XX.y` - Specific version, Alpine-based (runs Java 25)
+- `sonatype/nexus3:3.XX.y-alpine` - Explicit Alpine tag (runs Java 25)
 
 ## UBI Image Variant
 
 For users who prefer Red Hat Universal Base Image (UBI), a UBI-based variant is available using the `-ubi` tag suffix:
 
-- `sonatype/nexus3:3.XX.y-ubi` - Specific version, UBI-based (runs Java 21)
+- `sonatype/nexus3:3.XX.y-ubi` - Specific version, UBI-based (runs Java 25)
 
-The UBI-based container image can be created using [Dockerfile.java21](https://github.com/sonatype/docker-nexus3/blob/main/Dockerfile.java21).
+The UBI-based container image can be created using [Dockerfile.java25](https://github.com/sonatype/docker-nexus3/blob/main/Dockerfile.java25).
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ We are using `rspec` as the test framework. `serverspec` provides a docker backe
 
 ## Red Hat Certified Image
 
-A Red Hat certified container image can be created using [Dockerfile.rh.ubi](https://github.com/sonatype/docker-nexus3/blob/main/Dockerfile.rh.ubi) which is built to be compliant with Red Hat certification.
+A Red Hat certified container image can be created using [Dockerfile.rh.ubi.java25](https://github.com/sonatype/docker-nexus3/blob/main/Dockerfile.rh.ubi.java25) which is built to be compliant with Red Hat certification.
 The image includes additional meta data to comform with Kubernetes and OpenShift standards, a directory with the
 licenses applicable to the software and a man file for help on how to use the software. It also uses an ENTRYPOINT
 script the ensure the running user has access to the appropriate permissions for OpenShift 'restricted' SCC. 


### PR DESCRIPTION

JIRA_TICKET
https://sonatype.atlassian.net/browse/NEXUS-51563

**Description**                                      
                                                                                                                                                                                     
  Upgrades Docker images from Java 21 to Java 25 for Nexus Repository Manager                                                                                          
                                                                                                                                                                                     
  Changes

  - Renamed all Dockerfile.*.java21 files to Dockerfile.*.java25
  - Updated package installations:
    - Alpine: openjdk21 → openjdk25
    - UBI9: java-21-openjdk-headless → java-25-openjdk-headless
  - Updated all Jenkinsfiles
  - Updated README.md to reflect Java 25 runtime
  
  Verification

  - ✅ Alpine openjdk25 package confirmed available
  - ✅ UBI9 java-25-openjdk-headless package confirmed available
  - ✅ Docker images build successfully
  - ✅ NXRM containers start and run successfully with Java 25