### PR TITLE
release-3.90.3 - update docker files

### DIFF
--- a/Dockerfile.alpine.java21
+++ b/Dockerfile.alpine.java21
@@ -17,8 +17,8 @@ FROM alpine
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.91.0-07" \
-      release="3.91.0" \
+      version="3.90.3-03" \
+      release="3.90.3" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.91.0-07
+ARG NEXUS_VERSION=3.90.3-03
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=69267aa02492761fc7d9bdc61d01ab878374dbf08c5c54d1fa37c6c9f6044ca6
+ARG NEXUS_DOWNLOAD_SHA256_HASH=be93f955e7bd8c4dd954aa8557441db8b3e3e684d3ab7ca35ed6b56525972bd0
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype

--- a/Dockerfile.java21
+++ b/Dockerfile.java21
@@ -17,8 +17,8 @@ FROM redhat/ubi9-minimal
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.91.0-07" \
-      release="3.91.0" \
+      version="3.90.3-03" \
+      release="3.90.3" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.91.0-07
+ARG NEXUS_VERSION=3.90.3-03
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=69267aa02492761fc7d9bdc61d01ab878374dbf08c5c54d1fa37c6c9f6044ca6
+ARG NEXUS_DOWNLOAD_SHA256_HASH=be93f955e7bd8c4dd954aa8557441db8b3e3e684d3ab7ca35ed6b56525972bd0
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype

--- a/Dockerfile.rh.ubi.java21
+++ b/Dockerfile.rh.ubi.java21
@@ -17,8 +17,8 @@ FROM redhat/ubi9-minimal
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.91.0-07" \
-      release="3.91.0" \
+      version="3.90.3-03" \
+      release="3.90.3" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.91.0-07
+ARG NEXUS_VERSION=3.90.3-03
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=69267aa02492761fc7d9bdc61d01ab878374dbf08c5c54d1fa37c6c9f6044ca6
+ARG NEXUS_DOWNLOAD_SHA256_HASH=be93f955e7bd8c4dd954aa8557441db8b3e3e684d3ab7ca35ed6b56525972bd0
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype


### PR DESCRIPTION
Required to publish the release to docker hub

- This pull request downgrades the Nexus Repository Manager version from 3.91.0-07 to 3.90.3-03 across all Java 21 Dockerfiles. The associated SHA256 hash for the Nexus download has also been updated to match the new version.
