### PR TITLE
NEXUS-52723: Route sbom-release tags to correct IQ app after Alpine default

### DIFF
--- a/Jenkinsfile-sbom-release
+++ b/Jenkinsfile-sbom-release
@@ -17,12 +17,16 @@ REDHAT_SBOM_REPO_URL_BASE = "https://access.redhat.com/security/data/sbom/beta"
 REDHAT_CONTAINER_API_URL_BASE = "https://catalog.redhat.com/api/containers/v1"
 CYCLONEDX_VERSION = "1.5"
 SPDXMERGE_VERSION_TAG = "v0.2.0"
+// Tag → IQ application routing.
+// As of NEXUS-50546 (PR #275), the unsuffixed and `-alpine` tags both point at
+// the Alpine variant, while UBI is published only under the `-ubi` suffix.
+// See NEXUS-52723.
 NEXUS3_REPORT_BY_TAG = [
-  "^(\\d+\\.\\d+\\.\\d+)(-java\\d+)?-alpine\$" : "docker-nexus3-alpine",
-  "^(\\d+\\.\\d+\\.\\d+)(-java\\d+)?(-ubi)?\$" : "docker-nexus3"
+  "^(\\d+\\.\\d+\\.\\d+)(-java\\d+)?-ubi\$"          : "docker-nexus3",
+  "^(\\d+\\.\\d+\\.\\d+)(-java\\d+)?(-alpine)?\$"     : "docker-nexus3-alpine"
 ]
 DOCKER_NEXUS_IMAGE_NAME = "sonatype.repo.sonatype.app/docker-all/sonatype/nexus3"
-DEFAULT_NEXUS3_REPORT = "docker-nexus3"
+DEFAULT_NEXUS3_REPORT = "docker-nexus3-alpine"
 
 properties([
     parameters([


### PR DESCRIPTION
Jira: https://sonatype.atlassian.net/browse/NEXUS-52723

## Why

The `docker-nexus3` IQ application's component count silently dropped from ~1000 to ~700 a month ago. Root cause: NEXUS-50546 (PR #275, merged 2026-03-28) made Alpine the default base, so the unsuffixed `:X.Y.Z` tag now points at the Alpine variant. But the `NEXUS3_REPORT_BY_TAG` regex in `Jenkinsfile-sbom-release` was still routing the unsuffixed tag into the `docker-nexus3` IQ app (intended for UBI). The result:

- Alpine content has been getting scanned into the `docker-nexus3` IQ app (≈ ~700 component reading).
- The UBI variant we still publish under the `-ubi` suffix has had no IQ coverage from this job.

## What changes

| Tag | Before → IQ app | After → IQ app |
|---|---|---|
| `:X.Y.Z` (unsuffixed, Alpine post-NEXUS-50546) | `docker-nexus3` ❌ | `docker-nexus3-alpine` ✓ |
| `:X.Y.Z-alpine` | `docker-nexus3-alpine` | `docker-nexus3-alpine` |
| `:X.Y.Z-ubi` | `docker-nexus3` | `docker-nexus3` |
| Default fallback | `docker-nexus3` | `docker-nexus3-alpine` |

The `-ubi` rule is listed first in the map so it cannot be shadowed by the broader unsuffixed/`-alpine` rule.

## Side-effects reviewers should weigh in on

1. **Aggregate SBOM filenames change** for unsuffixed-tag runs of this job — they will be published as `docker-nexus3-alpine-aggregate-<ver>` instead of `docker-nexus3-aggregate-<ver>`. Anything downstream that consumes those SBOMs by exact name needs to be aware.
2. **UBI coverage isn't restored by this PR alone** — whatever upstream pipeline triggers `Jenkinsfile-sbom-release` per release also needs to start passing the `:<version>-ubi` tag (in addition to or instead of the unsuffixed/`-alpine` tag). Identifying that trigger and updating it is the natural follow-up to NEXUS-52723.
3. **No-op for callers passing `:*-alpine` directly** — those continue to route to `docker-nexus3-alpine` exactly as before.

## Verification

- Regex sanity-checked against representative tags: `3.92.2`, `3.92.2-alpine`, `3.92.2-ubi`, `3.92.2-java25`, `3.92.2-java25-alpine`, `3.92.2-java25-ubi` — all route as expected per the table above.
- Downstream code in `Jenkinsfile-sbom-release` keys off `nexusReportName` returned by `getNexusReportName(...)`, so SBOM filenames, document namespaces, and publish targets follow automatically.
- The UBI-SBOM lookup path (`base-image-ref` label + RedHat container API) is gated on the `image=` segment of the label, which only `Dockerfile.java25` builds set — so it correctly runs only for `:*-ubi` scans and is skipped for Alpine ones.

## Acceptance criteria (from NEXUS-52723)

- [x] `:*-ubi` tags route to `docker-nexus3` IQ app
- [x] Unsuffixed and `:*-alpine` tags route to `docker-nexus3-alpine` IQ app
- [x] `DEFAULT_NEXUS3_REPORT` updated accordingly
- [ ] (follow-up, not in this PR) Trigger of `Jenkinsfile-sbom-release` updated to also pass `:<version>-ubi` so UBI coverage is restored
- [ ] (follow-up) Plan for cleanup once `-ubi` tag is retired post-3.93.0
