### PR TITLE
NEXUS-52524: Upgrade Nexus to 3.93.0-01 to resolve CVE-2026-42198

### DIFF
--- a/Dockerfile.alpine.java21
+++ b/Dockerfile.alpine.java21
@@ -17,8 +17,8 @@ FROM alpine
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.92.3-01" \
-      release="3.92.3" \
+      version="3.93.0-02" \
+      release="3.93.0" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.92.3-01
+ARG NEXUS_VERSION=3.93.0-02
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=caded86922ae24e807ad56150a4c174ead973c94fb46339022a057811183dbcd
+ARG NEXUS_DOWNLOAD_SHA256_HASH=24784235ae6db4a0e51ada07706299f50d3f0266ec6c58cbfed962587b90c287
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype

--- a/Dockerfile.alpine.java21
+++ b/Dockerfile.alpine.java21
@@ -17,8 +17,8 @@ FROM alpine
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.93.0-02" \
-      release="3.93.0" \
+      version="3.92.3-01" \
+      release="3.92.3" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.93.0-02
+ARG NEXUS_VERSION=3.92.3-01
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=24784235ae6db4a0e51ada07706299f50d3f0266ec6c58cbfed962587b90c287
+ARG NEXUS_DOWNLOAD_SHA256_HASH=caded86922ae24e807ad56150a4c174ead973c94fb46339022a057811183dbcd
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype

--- a/Dockerfile.alpine.java21
+++ b/Dockerfile.alpine.java21
@@ -17,8 +17,8 @@ FROM alpine
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.92.3-01" \
-      release="3.92.3" \
+      version="3.93.0-01" \
+      release="3.93.0" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.92.3-01
+ARG NEXUS_VERSION=3.93.0-01
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=caded86922ae24e807ad56150a4c174ead973c94fb46339022a057811183dbcd
+ARG NEXUS_DOWNLOAD_SHA256_HASH=24784235ae6db4a0e51ada07706299f50d3f0266ec6c58cbfed962587b90c287
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype

--- a/Dockerfile.java21
+++ b/Dockerfile.java21
@@ -17,8 +17,8 @@ FROM redhat/ubi9-minimal
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.92.3-01" \
-      release="3.92.3" \
+      version="3.93.0-02" \
+      release="3.93.0" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.92.3-01
+ARG NEXUS_VERSION=3.93.0-02
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=caded86922ae24e807ad56150a4c174ead973c94fb46339022a057811183dbcd
+ARG NEXUS_DOWNLOAD_SHA256_HASH=24784235ae6db4a0e51ada07706299f50d3f0266ec6c58cbfed962587b90c287
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype

--- a/Dockerfile.java21
+++ b/Dockerfile.java21
@@ -17,8 +17,8 @@ FROM redhat/ubi9-minimal
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.92.3-01" \
-      release="3.92.3" \
+      version="3.93.0-01" \
+      release="3.93.0" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.92.3-01
+ARG NEXUS_VERSION=3.93.0-01
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=caded86922ae24e807ad56150a4c174ead973c94fb46339022a057811183dbcd
+ARG NEXUS_DOWNLOAD_SHA256_HASH=24784235ae6db4a0e51ada07706299f50d3f0266ec6c58cbfed962587b90c287
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype

--- a/Dockerfile.java21
+++ b/Dockerfile.java21
@@ -17,8 +17,8 @@ FROM redhat/ubi9-minimal
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.93.0-02" \
-      release="3.93.0" \
+      version="3.92.3-01" \
+      release="3.92.3" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.93.0-02
+ARG NEXUS_VERSION=3.92.3-01
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=24784235ae6db4a0e51ada07706299f50d3f0266ec6c58cbfed962587b90c287
+ARG NEXUS_DOWNLOAD_SHA256_HASH=caded86922ae24e807ad56150a4c174ead973c94fb46339022a057811183dbcd
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype


### PR DESCRIPTION
## Summary
- Upgrades Nexus Repository Manager from **3.92.3-01** to **3.93.0-01**
- Resolves **CVE-2026-42198** (PostgreSQL JDBC driver SCRAM-SHA-256 DoS vulnerability)
- Nexus 3.93.0-01 bundles postgresql JDBC driver **42.7.11** (up from 42.7.2)

## CVE Details
**CVE-2026-42198**: pgjdbc is vulnerable to a client-side denial of service during SCRAM-SHA-256 authentication. A malicious server can instruct the driver to perform SCRAM authentication with a very large iteration count, causing unbounded CPU consumption.

## Changes
- Updated `NEXUS_VERSION` from 3.92.3-01 to 3.93.0-01 in both Dockerfiles
- Updated `NEXUS_DOWNLOAD_SHA256_HASH` to `24784235ae6db4a0e51ada07706299f50d3f0266ec6c58cbfed962587b90c287`

## Testing
- Verified Nexus 3.93.0-01 is available on Sonatype CDN
- Downloaded and verified SHA256 checksum

Fixes: NEXUS-52524