### PR TITLE
NEXUS-54151: Remove OpenJDK demo artifacts from Java 21 images

### DIFF
--- a/Dockerfile.alpine.java21
+++ b/Dockerfile.alpine.java21
@@ -51,6 +51,7 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
 # Install Java & tar
 RUN apk add openjdk21 tar procps gzip curl shadow \
     && apk cache clean \
+    && find /usr/lib/jvm -maxdepth 2 -name demo -type d -exec rm -rf {} + \
     && groupadd --gid 200 -r nexus \
     && useradd --uid 200 -r nexus -g nexus -s /bin/false -d /opt/sonatype/nexus -c 'Nexus Repository Manager user'
 

--- a/Dockerfile.java21
+++ b/Dockerfile.java21
@@ -53,6 +53,7 @@ RUN microdnf update -y \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
           java-21-openjdk-headless tar procps shadow-utils gzip unzip glibc-langpack-en \
     && microdnf clean all \
+    && find /usr/lib/jvm -maxdepth 2 -name demo -type d -exec rm -rf {} + \
     && groupadd --gid 200 -r nexus \
     && useradd --uid 200 -r nexus -g nexus -s /bin/false -d /opt/sonatype/nexus -c 'Nexus Repository Manager user'
 

--- a/Dockerfile.rh.ubi.java21
+++ b/Dockerfile.rh.ubi.java21
@@ -53,6 +53,7 @@ RUN microdnf update -y \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
           java-21-openjdk-headless tar procps shadow-utils gzip unzip glibc-langpack-en \
     && microdnf clean all \
+    && find /usr/lib/jvm -maxdepth 2 -name demo -type d -exec rm -rf {} + \
     && groupadd --gid 200 -r nexus \
     && useradd --uid 200 -r nexus -g nexus -s /bin/false -d /opt/sonatype/nexus -c 'Nexus Repository Manager user'
 


### PR DESCRIPTION
## Jira Ticket 54151
**Associated Ticket:** https://sonatype.atlassian.net/browse/NEXUS-54151
**nexus-internal PR:** https://github.com/sonatype/nexus-internal/pull/16981

## Description

Add `find /usr/lib/jvm -maxdepth 2 -name demo -type d -exec rm -rf {} +` to all three Java 21 Dockerfiles (Alpine, UBI standard, UBI Red Hat certified). The demo directory under the openjdk21 package contains non-runtime demonstration JARs that trigger IQ Component-Unknown policy violations. Using find instead of a hardcoded path keeps the removal version-agnostic across point releases and future JDK upgrades.

This pull request makes the following changes:

**docker-nexus3 — NEXUS-54151-iq-policy-violations**

3 Dockerfiles modified:
- Dockerfile.alpine.java21 — Alpine-based image
- Dockerfile.java21 — RHEL/microdnf image
- Dockerfile.rh.ubi.java21 — Red Hat UBI image

---
**nexus-internal — NEXUS-54151-iq-policy-violations**

2 Dockerfiles modified:
- private/docker/Dockerfile.alpine — Alpine-based image
- private/docker/Dockerfile — microdnf/UBI image

---
**The Change (identical in both repos)**

In each modified Dockerfile, this line was added immediately after the Java installation step:

&& find /usr/lib/jvm -maxdepth 2 -name demo -type d -exec rm -rf {} +

This removes any directory named demo within 2 levels of /usr/lib/jvm — which is where Alpine's openjdk21 package places the demo/jfc/ artifacts that were triggering IQ Component-Unknown policy violations. The maxdepth 2 and -type d constraints make it version-agnostic and surgical — it only removes demo directories, leaving everything else (including lib/jrt-fs.jar) intact.
