### PR TITLE
NEXUS-54284: Pin UBI9 minimal base image to digest

### DIFF
--- a/Dockerfile.java21
+++ b/Dockerfile.java21
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM redhat/ubi9-minimal
+# Pin the UBI 9 minimal base image by digest (instead of the floating :latest tag) for reproducible
+# builds and a stable image identity. This digest is redhat/ubi9-minimal:latest as of 2026-07-31;
+# update it deliberately when moving to a newer UBI build.
+FROM redhat/ubi9-minimal@sha256:17fd831ced9434de0a984d60b3fbe61008308261ba98bbc348d6fbdef05fa7c0
 
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \

--- a/Dockerfile.rh.ubi.java21
+++ b/Dockerfile.rh.ubi.java21
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM redhat/ubi9-minimal
+# Pin the UBI 9 minimal base image by digest (instead of the floating :latest tag) for reproducible
+# builds and a stable image identity. This digest is redhat/ubi9-minimal:latest as of 2026-07-31;
+# update it deliberately when moving to a newer UBI build.
+FROM redhat/ubi9-minimal@sha256:17fd831ced9434de0a984d60b3fbe61008308261ba98bbc348d6fbdef05fa7c0
 
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \


### PR DESCRIPTION
Jira: https://sonatype.atlassian.net/browse/NEXUS-54284

## Why

The UBI9 image builds pull `redhat/ubi9-minimal` via the floating `:latest` tag, which keeps drifting to new digests. That makes builds non-reproducible and, when built through the Sonatype Firewall proxy, the moving identity means a Firewall waiver never sticks and the build fails to pull its `FROM` base.

Companion to the same pin in `nexus-internal` (`private/docker/Dockerfile`), and the earlier moby/buildkit digest pin (NEXUS-54249).

## What

Pin the UBI9 base image to the current manifest-list digest in both Java 21 UBI Dockerfiles:

- `Dockerfile.java21`
- `Dockerfile.rh.ubi.java21`

```
FROM redhat/ubi9-minimal@sha256:17fd831ced9434de0a984d60b3fbe61008308261ba98bbc348d6fbdef05fa7c0
```

## Notes

- `sha256:17fd831c…` is `redhat/ubi9-minimal:latest` as of 2026-07-31 — a multi-arch manifest list (amd64, arm64/v8, s390x, ppc64le), so multi-arch builds are unaffected.
- The legacy `Dockerfile` uses UBI8 (`ubi8/ubi-minimal`) and the alpine variants use `alpine`; neither is changed here.
- Update the digest deliberately when moving to a newer UBI build.
