### PR TITLE
NEXUS-54360: Remove jrt-fs.jar from UBI Java 21 image

### DIFF
--- a/Dockerfile.rh.ubi.java21
+++ b/Dockerfile.rh.ubi.java21
@@ -51,12 +51,17 @@ ENV NEXUS_HOME=${SONATYPE_DIR}/nexus \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \
     DOCKER_TYPE='rh-docker'
 
-# Install Java, tar, and unzip
+# Install Java, tar, and unzip.
+# Also drop jrt-fs.jar (the jrt: FileSystemProvider, jdk.internal.jrtfs): it is unused by the
+# classpath/Karaf-launched Nexus runtime, and IQ flags this unpublished JDK-internal jar as an
+# unknown component (NEXUS-54360; mirrors NEXUS-54299 alpine / NEXUS-54161 aws / FIRE-722).
+# In UBI it ships at /usr/lib/jvm/java-21-openjdk-<version>/lib/jrt-fs.jar.
 RUN microdnf update -y \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
           java-21-openjdk-headless tar procps shadow-utils gzip unzip glibc-langpack-en \
     && microdnf clean all \
     && find /usr/lib/jvm -maxdepth 2 -name demo -type d -exec rm -rf {} + \
+    && find /usr/lib/jvm -maxdepth 3 -name jrt-fs.jar -exec rm -f {} + \
     && groupadd --gid 200 -r nexus \
     && useradd --uid 200 -r nexus -g nexus -s /bin/false -d /opt/sonatype/nexus -c 'Nexus Repository Manager user'
 


### PR DESCRIPTION
Jira: https://sonatype.atlassian.net/browse/NEXUS-54360

## Why

Sonatype IQ raises a **Component-Unknown (Threat Level 8)** policy violation against `jrt-fs.jar` in the docker-nexus3 Stage Release Report. `jrt-fs.jar` is the `jrt:` FileSystemProvider (`jdk.internal.jrtfs`) — a JDK-internal jar that is **not published to any public repository**, so IQ cannot identify it and flags it as an unknown component. It is unused by the classpath/Karaf-launched Nexus runtime, so it is safe to remove.

This applies the same fix already shipped for the Alpine image (NEXUS-54299) and repository-cloud-aws-docker (NEXUS-54161 / FIRE-722) to the UBI image, which never received it.

## Where it's located (verified)

Hashed the candidate jar inside the actual pinned UBI9 minimal base image with `java-21-openjdk-headless` installed:

```
c1bd8bcfac766f216e06b445fc55dd79d443d7f6  /usr/lib/jvm/java-21-openjdk-21.0.12.0.8-1.2.el9.x86_64/lib/jrt-fs.jar
```

The `java-21-openjdk-<version>` directory name is version-specific, so a `find`-based removal is used (consistent with the existing OpenJDK `demo` removal on the same `RUN` step).

## What changed

`Dockerfile.rh.ubi.java21` — added to the Java install `RUN` step:

```dockerfile
&& find /usr/lib/jvm -maxdepth 3 -name jrt-fs.jar -exec rm -f {} + \
```

The rationale comment sits **above** the `RUN` (not inline) because BuildKit rejects full-line comments inside a `RUN` continuation (`unknown instruction: &&`).

## Verification

Built the base + install step against the pinned UBI9 digest:

- ✅ Build succeeds
- ✅ `jrt-fs.jar` is removed (no match under `/`)
- ✅ `java -version` still reports OpenJDK 21.0.12

Follow-up: rescan with Sonatype IQ to confirm the unknown-component violation clears.
