### PR TITLE
NEXUS-54669: Remove openssl-fips-provider packages to resolve CVE-2026-2673

### DIFF
--- a/Dockerfile.alpine.java21
+++ b/Dockerfile.alpine.java21
@@ -17,8 +17,8 @@ FROM alpine
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.92.3-01" \
-      release="3.92.3" \
+      version="3.93.0-02" \
+      release="3.93.0" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.92.3-01
+ARG NEXUS_VERSION=3.93.0-02
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=caded86922ae24e807ad56150a4c174ead973c94fb46339022a057811183dbcd
+ARG NEXUS_DOWNLOAD_SHA256_HASH=24784235ae6db4a0e51ada07706299f50d3f0266ec6c58cbfed962587b90c287
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype

--- a/Dockerfile.alpine.java21
+++ b/Dockerfile.alpine.java21
@@ -17,8 +17,8 @@ FROM alpine
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.93.0-02" \
-      release="3.93.0" \
+      version="3.92.3-01" \
+      release="3.92.3" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.93.0-02
+ARG NEXUS_VERSION=3.92.3-01
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=24784235ae6db4a0e51ada07706299f50d3f0266ec6c58cbfed962587b90c287
+ARG NEXUS_DOWNLOAD_SHA256_HASH=caded86922ae24e807ad56150a4c174ead973c94fb46339022a057811183dbcd
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype

--- a/Dockerfile.java21
+++ b/Dockerfile.java21
@@ -17,8 +17,8 @@ FROM redhat/ubi9-minimal
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.92.3-01" \
-      release="3.92.3" \
+      version="3.93.0-02" \
+      release="3.93.0" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.92.3-01
+ARG NEXUS_VERSION=3.93.0-02
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=caded86922ae24e807ad56150a4c174ead973c94fb46339022a057811183dbcd
+ARG NEXUS_DOWNLOAD_SHA256_HASH=24784235ae6db4a0e51ada07706299f50d3f0266ec6c58cbfed962587b90c287
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype

--- a/Dockerfile.java21
+++ b/Dockerfile.java21
@@ -17,8 +17,8 @@ FROM redhat/ubi9-minimal
 LABEL name="Nexus Repository Manager" \
       maintainer="Sonatype <support@sonatype.com>" \
       vendor=Sonatype \
-      version="3.93.0-02" \
-      release="3.93.0" \
+      version="3.92.3-01" \
+      release="3.92.3" \
       url="https://sonatype.com" \
       summary="The Nexus Repository Manager server \
           with universal support for popular component formats." \
@@ -36,9 +36,9 @@ LABEL name="Nexus Repository Manager" \
       io.openshift.expose-services="8081:8081" \
       io.openshift.tags="Sonatype,Nexus,Repository Manager"
 
-ARG NEXUS_VERSION=3.93.0-02
+ARG NEXUS_VERSION=3.92.3-01
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/sonatype-nexus-repository-${NEXUS_VERSION}-assembly.zip
-ARG NEXUS_DOWNLOAD_SHA256_HASH=24784235ae6db4a0e51ada07706299f50d3f0266ec6c58cbfed962587b90c287
+ARG NEXUS_DOWNLOAD_SHA256_HASH=caded86922ae24e807ad56150a4c174ead973c94fb46339022a057811183dbcd
 
 # configure nexus runtime
 ENV SONATYPE_DIR=/opt/sonatype


### PR DESCRIPTION
Jira: https://sonatype.atlassian.net/browse/NEXUS-54669

## Why

The `openssl-fips-provider` and `openssl-fips-provider-so` packages (`3.0.7-11.el9_8`) shipped in the `redhat/ubi9-minimal` base image are flagged for CVE-2026-2673 (CVSS 7.3, Security-High policy violation). No RHEL patch is currently available — `microdnf check-update` returns nothing for these packages.

Importantly, the CVE description itself states: _"No OpenSSL FIPS modules are affected by this issue — the code in question lies outside the FIPS boundary."_ These packages have no reverse dependencies in the image and Nexus does not require FIPS mode, making removal the correct remediation.

This also resolves the sibling violation [NEXUS-54667](https://sonatype.atlassian.net/browse/NEXUS-54667) (`openssl-fips-provider`) in the same change.

## What changed

- `Dockerfile.rh.ubi.java21` — added `rpm --erase --nodeps openssl-fips-provider openssl-fips-provider-so` to the existing package removal step
- `Dockerfile.java21` — same, alongside the existing `cups-libs`/`expat` removals

`openssl-libs-3.5.5` (providing `libssl.so.3` / `libcrypto.so.3`) is untouched — TLS continues to work normally.

## Local testing evidence

**Package removal verified:**
```
Before: openssl-fips-provider-3.0.7-11.el9_8, openssl-fips-provider-so-3.0.7-11.el9_8, openssl-libs-3.5.5-6.el9_8
After:  openssl-libs-3.5.5-6.el9_8 only
```

**Full image build:** `Dockerfile.rh.ubi.java21` built end-to-end without errors. Both packages removed cleanly in the final layer.

**Nexus starts correctly:** Container launched from the fixed image — `Started Sonatype Nexus COMMUNITY 3.92.3-01`, HTTP 200 on port 8081.

[NEXUS-54667]: https://sonatype.atlassian.net/browse/NEXUS-54667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ